### PR TITLE
Redesign issue card hover state and smart title truncation

### DIFF
--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -122,13 +122,13 @@ export default function IssueCard({ issue }: Props) {
             </div>
 
             {/* Title — single line, middle-truncated */}
-            <span className={`flex-1 min-w-0 overflow-hidden whitespace-nowrap text-gray-900 font-medium leading-none transition-opacity ${hovered ? 'opacity-30' : ''}`}>
+            <span className="flex-1 min-w-0 overflow-hidden whitespace-nowrap text-gray-900 font-medium leading-none">
               {truncateMiddle(issue.title, 45)}
             </span>
 
             {/* Assignees — inline so they never add height */}
             {issue.assignees.length > 0 && (
-              <div className={`flex shrink-0 -space-x-1 transition-opacity ${hovered ? 'opacity-0' : ''}`}>
+              <div className="flex shrink-0 -space-x-1">
                 {issue.assignees.map((user) => (
                   <img key={user.login} src={user.avatar_url} alt={user.login} title={user.login} className="w-4 h-4 rounded-full ring-1 ring-white" />
                 ))}

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -19,10 +19,12 @@ export default function IssueCard({ issue, hideLabels }: Props) {
   const { closeIssue, deleteIssue } = useAppStore();
   const [showEdit, setShowEdit] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [hovered, setHovered] = useState(false);
   const [showBadgeTip, setShowBadgeTip] = useState(false);
   const [calloutStyle, setCalloutStyle] = useState<React.CSSProperties | null>(null);
   const cardRef = useRef<HTMLDivElement>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const calloutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const leaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const statusLabel = issue.labels.find(l => l.name.startsWith('s_'));
   const statusName = statusLabel ? statusLabel.name.slice(2) : null;
@@ -31,8 +33,10 @@ export default function IssueCard({ issue, hideLabels }: Props) {
     ? { backgroundColor: '#eff6ff', color: '#2563eb', border: '1px solid #bfdbfe' }
     : { backgroundColor: '#f0fdf4', color: '#16a34a', border: '1px solid #bbf7d0' };
 
-  function handleCardEnter() {
-    timerRef.current = setTimeout(() => {
+  function onCardEnter() {
+    if (leaveTimerRef.current) clearTimeout(leaveTimerRef.current);
+    setHovered(true);
+    calloutTimerRef.current = setTimeout(() => {
       if (!cardRef.current) return;
       const r = cardRef.current.getBoundingClientRect();
       const W = 280, H = 180;
@@ -43,9 +47,18 @@ export default function IssueCard({ issue, hideLabels }: Props) {
     }, 400);
   }
 
-  function handleCardLeave() {
-    if (timerRef.current) clearTimeout(timerRef.current);
+  function onCardLeave() {
+    if (calloutTimerRef.current) clearTimeout(calloutTimerRef.current);
     setCalloutStyle(null);
+    leaveTimerRef.current = setTimeout(() => setHovered(false), 120);
+  }
+
+  function onTrayEnter() {
+    if (leaveTimerRef.current) clearTimeout(leaveTimerRef.current);
+  }
+
+  function onTrayLeave() {
+    leaveTimerRef.current = setTimeout(() => setHovered(false), 120);
   }
 
   async function handleClose(e: React.MouseEvent) {
@@ -71,19 +84,19 @@ export default function IssueCard({ issue, hideLabels }: Props) {
     <>
       <div
         ref={cardRef}
-        onMouseEnter={handleCardEnter}
-        onMouseLeave={handleCardLeave}
-        className={`relative group select-none cursor-pointer hover:z-20 text-sm ${
+        className={`relative select-none cursor-pointer text-sm ${hovered ? 'z-20' : ''} ${
           busy ? 'opacity-40 pointer-events-none' :
           issue.state === 'closed' ? 'opacity-60' : ''
         }`}
       >
         {/* Card surface — z-10 so it sits visually in front of the tray */}
-        <div className={`relative z-10 bg-white rounded-lg border px-2 py-1.5 shadow-sm transition-all ${
-          issue.state === 'closed'
-            ? 'border-gray-200 hover:border-gray-300 hover:shadow-md'
-            : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
-        }`}>
+        <div
+          onMouseEnter={onCardEnter}
+          onMouseLeave={onCardLeave}
+          className={`relative z-10 bg-white rounded-lg border px-2 py-1.5 shadow-sm transition-all ${
+            hovered ? 'border-gray-300 shadow-md' : 'border-gray-200'
+          }`}
+        >
 
         {/* Single-line title row */}
         <div className="flex items-center gap-1.5 min-w-0">
@@ -138,13 +151,16 @@ export default function IssueCard({ issue, hideLabels }: Props) {
 
         </div>{/* end card surface */}
 
-        {/* Clip wrapper — z-0 so it stays behind the card surface (z-10) */}
-        <div className="absolute left-0 right-0 top-full z-0 overflow-hidden rounded-b-lg">
-          <div className="
-            -translate-y-full group-hover:translate-y-0 transition-transform duration-200 ease-out
+        {/* Clip wrapper — pointer-events-none while hidden so cursor approaching from below is ignored */}
+        <div
+          onMouseEnter={onTrayEnter}
+          onMouseLeave={onTrayLeave}
+          className={`absolute left-0 right-0 top-full z-0 overflow-hidden rounded-b-lg ${hovered ? 'pointer-events-auto' : 'pointer-events-none'}`}
+        >
+          <div className={`transition-transform duration-200 ease-out ${hovered ? 'translate-y-0' : '-translate-y-full'}
             bg-gray-100 border-x border-b border-gray-200 rounded-b-lg
             flex items-center justify-end gap-1 px-2 py-1.5
-          ">
+          `}>
             <button
               onClick={e => { e.stopPropagation(); setShowEdit(true); }}
               title="Edit issue"

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -73,10 +73,10 @@ export default function IssueCard({ issue, hideLabels }: Props) {
         ref={cardRef}
         onMouseEnter={handleCardEnter}
         onMouseLeave={handleCardLeave}
-        className={`relative group bg-white rounded-lg border px-2 py-1.5 text-sm select-none transition-shadow cursor-pointer ${
+        className={`relative group bg-white rounded-lg border px-2 py-1.5 text-sm select-none transition-shadow cursor-pointer shadow-sm ${
           busy ? 'opacity-40 pointer-events-none' :
-          issue.state === 'closed' ? 'opacity-60 border-gray-200 hover:border-gray-300 hover:shadow-sm' :
-          'border-gray-200 hover:border-gray-300 hover:shadow-sm'
+          issue.state === 'closed' ? 'opacity-60 border-gray-200 hover:border-gray-300 hover:shadow-md' :
+          'border-gray-200 hover:border-gray-300 hover:shadow-md'
         }`}
       >
         {/* Single-line title row */}
@@ -149,38 +149,41 @@ export default function IssueCard({ issue, hideLabels }: Props) {
           </div>
         )}
 
-        {/* Action row — absolutely positioned below the card, no layout reflow */}
-        <div className="absolute left-0 right-0 top-full z-10
-                        opacity-0 group-hover:opacity-100 transition-opacity
-                        bg-gray-100 border-x border-b border-gray-200 rounded-b-lg
-                        flex items-center justify-end gap-1 px-2 py-1.5">
-          <button
-            onClick={e => { e.stopPropagation(); setShowEdit(true); }}
-            title="Edit issue"
-            className="text-gray-400 hover:text-blue-500 p-1 rounded-md border border-gray-200 bg-white hover:border-blue-200 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-            </svg>
-          </button>
-          <button
-            onClick={handleClose}
-            title="Close issue"
-            className="text-gray-400 hover:text-orange-500 p-1 rounded-md border border-gray-200 bg-white hover:border-orange-200 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-            </svg>
-          </button>
-          <button
-            onClick={handleDelete}
-            title="Delete issue permanently"
-            className="text-gray-400 hover:text-red-500 p-1 rounded-md border border-gray-200 bg-white hover:border-red-200 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-            </svg>
-          </button>
+        {/* Clip wrapper — overflow-hidden so the tray slides out from under the card */}
+        <div className="absolute left-0 right-0 top-full z-10 overflow-hidden rounded-b-lg">
+          <div className="
+            -translate-y-full group-hover:translate-y-0 transition-transform duration-200 ease-out
+            bg-gray-100 border-x border-b border-gray-200 rounded-b-lg
+            flex items-center justify-end gap-1 px-2 py-1.5
+          ">
+            <button
+              onClick={e => { e.stopPropagation(); setShowEdit(true); }}
+              title="Edit issue"
+              className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+              </svg>
+            </button>
+            <button
+              onClick={handleClose}
+              title="Close issue"
+              className="text-orange-500 p-1 rounded-md border border-orange-200 bg-orange-50 hover:bg-orange-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+            </button>
+            <button
+              onClick={handleDelete}
+              title="Delete issue permanently"
+              className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -26,11 +26,10 @@ export default function IssueCard({ issue, hideLabels }: Props) {
 
   const statusLabel = issue.labels.find(l => l.name.startsWith('s_'));
   const statusName = statusLabel ? statusLabel.name.slice(2) : null;
-  const statusColor = statusLabel?.color ?? null;
 
-  const badgeStyle: React.CSSProperties = statusColor
-    ? { backgroundColor: `#${statusColor}28`, color: `#${statusColor}`, border: `1px solid #${statusColor}50` }
-    : { backgroundColor: '#f3f4f6', color: '#6b7280', border: '1px solid #e5e7eb' };
+  const badgeStyle: React.CSSProperties = issue.state === 'open'
+    ? { backgroundColor: '#eff6ff', color: '#2563eb', border: '1px solid #bfdbfe' }
+    : { backgroundColor: '#f0fdf4', color: '#16a34a', border: '1px solid #bbf7d0' };
 
   function handleCardEnter() {
     timerRef.current = setTimeout(() => {

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -158,36 +158,37 @@ export default function IssueCard({ issue, hideLabels }: Props) {
           className={`absolute left-0 right-0 top-full z-0 overflow-hidden rounded-b-lg ${hovered ? 'pointer-events-auto' : 'pointer-events-none'}`}
         >
           <div className={`transition-transform duration-200 ease-out ${hovered ? 'translate-y-0' : '-translate-y-full'}
-            bg-gray-100 border-x border-b border-gray-200 rounded-b-lg
-            flex items-center justify-end gap-1 px-2 py-1.5
+            flex items-center justify-end px-2 py-1.5
           `}>
-            <button
-              onClick={e => { e.stopPropagation(); setShowEdit(true); }}
-              title="Edit issue"
-              className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-              </svg>
-            </button>
-            <button
-              onClick={handleClose}
-              title="Close issue"
-              className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-            </button>
-            <button
-              onClick={handleDelete}
-              title="Delete issue permanently"
-              className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-              </svg>
-            </button>
+            <div className="flex items-center gap-1 bg-gray-100 border border-gray-200 rounded-lg px-1.5 py-1 shadow-sm">
+              <button
+                onClick={e => { e.stopPropagation(); setShowEdit(true); }}
+                title="Edit issue"
+                className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                </svg>
+              </button>
+              <button
+                onClick={handleClose}
+                title="Close issue"
+                className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </button>
+              <button
+                onClick={handleDelete}
+                title="Delete issue permanently"
+                className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -15,7 +15,7 @@ interface Props {
   showStatus?: boolean;
 }
 
-export default function IssueCard({ issue, hideLabels }: Props) {
+export default function IssueCard({ issue }: Props) {
   const { closeIssue, deleteIssue } = useAppStore();
   const [showEdit, setShowEdit] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -24,7 +24,6 @@ export default function IssueCard({ issue, hideLabels }: Props) {
   const [calloutStyle, setCalloutStyle] = useState<React.CSSProperties | null>(null);
   const cardRef = useRef<HTMLDivElement>(null);
   const calloutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const leaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const statusLabel = issue.labels.find(l => l.name.startsWith('s_'));
   const statusName = statusLabel ? statusLabel.name.slice(2) : null;
@@ -34,7 +33,6 @@ export default function IssueCard({ issue, hideLabels }: Props) {
     : { backgroundColor: '#f0fdf4', color: '#16a34a', border: '1px solid #bbf7d0' };
 
   function onCardEnter() {
-    if (leaveTimerRef.current) clearTimeout(leaveTimerRef.current);
     setHovered(true);
     calloutTimerRef.current = setTimeout(() => {
       if (!cardRef.current) return;
@@ -48,17 +46,9 @@ export default function IssueCard({ issue, hideLabels }: Props) {
   }
 
   function onCardLeave() {
+    setHovered(false);
     if (calloutTimerRef.current) clearTimeout(calloutTimerRef.current);
     setCalloutStyle(null);
-    leaveTimerRef.current = setTimeout(() => setHovered(false), 120);
-  }
-
-  function onTrayEnter() {
-    if (leaveTimerRef.current) clearTimeout(leaveTimerRef.current);
-  }
-
-  function onTrayLeave() {
-    leaveTimerRef.current = setTimeout(() => setHovered(false), 120);
   }
 
   async function handleClose(e: React.MouseEvent) {
@@ -84,112 +74,99 @@ export default function IssueCard({ issue, hideLabels }: Props) {
     <>
       <div
         ref={cardRef}
+        onMouseEnter={onCardEnter}
+        onMouseLeave={onCardLeave}
         className={`relative select-none cursor-pointer text-sm ${hovered ? 'z-20' : ''} ${
           busy ? 'opacity-40 pointer-events-none' :
           issue.state === 'closed' ? 'opacity-60' : ''
         }`}
       >
-        {/* Card surface — z-10 so it sits visually in front of the tray */}
-        <div
-          onMouseEnter={onCardEnter}
-          onMouseLeave={onCardLeave}
-          className={`relative z-10 bg-white rounded-lg border px-2 py-1.5 shadow-sm transition-all ${
-            hovered ? 'border-gray-300 shadow-md' : 'border-gray-200'
-          }`}
-        >
+        <div className={`relative bg-white rounded-lg border px-2 py-1.5 shadow-sm transition-all ${
+          hovered ? 'border-gray-300 shadow-md' : 'border-gray-200'
+        }`}>
 
-        {/* Single-line title row */}
-        <div className="flex items-center gap-1.5 min-w-0">
+          {/* Single-line title row */}
+          <div className="flex items-center gap-1.5 min-w-0">
 
-          {/* ID badge — background reflects status color; tooltip on hover */}
-          <div
-            className="relative shrink-0"
-            onMouseEnter={() => setShowBadgeTip(true)}
-            onMouseLeave={() => setShowBadgeTip(false)}
-          >
-            <a
-              href={issue.html_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={e => e.stopPropagation()}
-              className="block px-1.5 py-0.5 rounded-full text-xs font-medium tabular-nums leading-none transition-colors"
-              style={badgeStyle}
+            {/* ID badge — background reflects open/closed state; tooltip on hover */}
+            <div
+              className="relative shrink-0"
+              onMouseEnter={() => setShowBadgeTip(true)}
+              onMouseLeave={() => setShowBadgeTip(false)}
             >
-              #{issue.number}
-            </a>
+              <a
+                href={issue.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+                className="block px-1.5 py-0.5 rounded-full text-xs font-medium tabular-nums leading-none transition-colors"
+                style={badgeStyle}
+              >
+                #{issue.number}
+              </a>
 
-            {showBadgeTip && (
-              <div className="absolute bottom-full left-0 mb-1.5 z-20 bg-gray-900 text-white text-xs rounded-md px-2.5 py-2 shadow-lg whitespace-nowrap min-w-max">
-                {statusName && <div className="font-semibold mb-1">{statusName}</div>}
-                <a
-                  href={issue.html_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={e => e.stopPropagation()}
-                  className="text-blue-300 hover:text-blue-200 transition-colors"
-                >
-                  View on GitHub →
-                </a>
+              {showBadgeTip && (
+                <div className="absolute bottom-full left-0 mb-1.5 z-30 bg-gray-900 text-white text-xs rounded-md px-2.5 py-2 shadow-lg whitespace-nowrap min-w-max">
+                  {statusName && <div className="font-semibold mb-1">{statusName}</div>}
+                  <a
+                    href={issue.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={e => e.stopPropagation()}
+                    className="text-blue-300 hover:text-blue-200 transition-colors"
+                  >
+                    View on GitHub →
+                  </a>
+                </div>
+              )}
+            </div>
+
+            {/* Title — single line, middle-truncated */}
+            <span className={`flex-1 min-w-0 overflow-hidden whitespace-nowrap text-gray-900 font-medium leading-none transition-opacity ${hovered ? 'opacity-30' : ''}`}>
+              {truncateMiddle(issue.title, 45)}
+            </span>
+
+            {/* Assignees — inline so they never add height */}
+            {issue.assignees.length > 0 && (
+              <div className={`flex shrink-0 -space-x-1 transition-opacity ${hovered ? 'opacity-0' : ''}`}>
+                {issue.assignees.map((user) => (
+                  <img key={user.login} src={user.avatar_url} alt={user.login} title={user.login} className="w-4 h-4 rounded-full ring-1 ring-white" />
+                ))}
               </div>
             )}
           </div>
 
-          {/* Title — single line, middle-truncated */}
-          <span className="flex-1 min-w-0 overflow-hidden whitespace-nowrap text-gray-900 font-medium leading-none">
-            {truncateMiddle(issue.title, 45)}
-          </span>
-
-          {/* Assignees — inline so they never add height */}
-          {issue.assignees.length > 0 && (
-            <div className="flex shrink-0 -space-x-1">
-              {issue.assignees.map((user) => (
-                <img key={user.login} src={user.avatar_url} alt={user.login} title={user.login} className="w-4 h-4 rounded-full ring-1 ring-white" />
-              ))}
-            </div>
-          )}
-        </div>
-
-        </div>{/* end card surface */}
-
-        {/* Clip wrapper — pointer-events-none while hidden so cursor approaching from below is ignored */}
-        <div
-          onMouseEnter={onTrayEnter}
-          onMouseLeave={onTrayLeave}
-          className={`absolute left-0 right-0 top-full z-0 overflow-hidden rounded-b-lg ${hovered ? 'pointer-events-auto' : 'pointer-events-none'}`}
-        >
-          <div className={`transition-transform duration-200 ease-out ${hovered ? 'translate-y-0' : '-translate-y-full'}
-            flex items-center justify-end px-2 py-1.5
-          `}>
-            <div className="flex items-center gap-1 bg-gray-100 border border-gray-200 rounded-lg px-1.5 py-1 shadow-sm">
-              <button
-                onClick={e => { e.stopPropagation(); setShowEdit(true); }}
-                title="Edit issue"
-                className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                </svg>
-              </button>
-              <button
-                onClick={handleClose}
-                title="Close issue"
-                className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                </svg>
-              </button>
-              <button
-                onClick={handleDelete}
-                title="Delete issue permanently"
-                className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-                </svg>
-              </button>
-            </div>
+          {/* Action buttons — absolute overlay on the right, visible on hover */}
+          <div className={`absolute right-1.5 inset-y-0 flex items-center gap-1 transition-opacity ${hovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+            <button
+              onClick={e => { e.stopPropagation(); setShowEdit(true); }}
+              title="Edit issue"
+              className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+              </svg>
+            </button>
+            <button
+              onClick={handleClose}
+              title="Close issue"
+              className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+            </button>
+            <button
+              onClick={handleDelete}
+              title="Delete issue permanently"
+              className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+            </button>
           </div>
+
         </div>
       </div>
 

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -152,12 +152,12 @@ export default function IssueCard({ issue, hideLabels }: Props) {
         {/* Action row — absolutely positioned below the card, no layout reflow */}
         <div className="absolute left-0 right-0 top-full z-10
                         opacity-0 group-hover:opacity-100 transition-opacity
-                        bg-white border-x border-b border-gray-200 rounded-b-lg
-                        flex items-center justify-end gap-1 px-2 py-1 shadow-sm">
+                        bg-gray-100 border-x border-b border-gray-200 rounded-b-lg
+                        flex items-center justify-end gap-1 px-2 py-1.5">
           <button
             onClick={e => { e.stopPropagation(); setShowEdit(true); }}
             title="Edit issue"
-            className="text-gray-400 hover:text-blue-500 p-0.5 rounded transition-colors"
+            className="text-gray-400 hover:text-blue-500 p-1 rounded-md border border-gray-200 bg-white hover:border-blue-200 transition-colors"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
               <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
@@ -166,7 +166,7 @@ export default function IssueCard({ issue, hideLabels }: Props) {
           <button
             onClick={handleClose}
             title="Close issue"
-            className="text-gray-400 hover:text-orange-500 p-0.5 rounded transition-colors"
+            className="text-gray-400 hover:text-orange-500 p-1 rounded-md border border-gray-200 bg-white hover:border-orange-200 transition-colors"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
@@ -175,7 +175,7 @@ export default function IssueCard({ issue, hideLabels }: Props) {
           <button
             onClick={handleDelete}
             title="Delete issue permanently"
-            className="text-gray-400 hover:text-red-500 p-0.5 rounded transition-colors"
+            className="text-gray-400 hover:text-red-500 p-1 rounded-md border border-gray-200 bg-white hover:border-red-200 transition-colors"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -73,12 +73,18 @@ export default function IssueCard({ issue, hideLabels }: Props) {
         ref={cardRef}
         onMouseEnter={handleCardEnter}
         onMouseLeave={handleCardLeave}
-        className={`relative group bg-white rounded-lg border px-2 py-1.5 text-sm select-none transition-shadow cursor-pointer shadow-sm ${
+        className={`relative group select-none cursor-pointer hover:z-20 text-sm ${
           busy ? 'opacity-40 pointer-events-none' :
-          issue.state === 'closed' ? 'opacity-60 border-gray-200 hover:border-gray-300 hover:shadow-md' :
-          'border-gray-200 hover:border-gray-300 hover:shadow-md'
+          issue.state === 'closed' ? 'opacity-60' : ''
         }`}
       >
+        {/* Card surface — z-10 so it sits visually in front of the tray */}
+        <div className={`relative z-10 bg-white rounded-lg border px-2 py-1.5 shadow-sm transition-all ${
+          issue.state === 'closed'
+            ? 'border-gray-200 hover:border-gray-300 hover:shadow-md'
+            : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
+        }`}>
+
         {/* Single-line title row */}
         <div className="flex items-center gap-1.5 min-w-0">
 
@@ -149,8 +155,10 @@ export default function IssueCard({ issue, hideLabels }: Props) {
           </div>
         )}
 
-        {/* Clip wrapper — overflow-hidden so the tray slides out from under the card */}
-        <div className="absolute left-0 right-0 top-full z-10 overflow-hidden rounded-b-lg">
+        </div>{/* end card surface */}
+
+        {/* Clip wrapper — z-0 so it stays behind the card surface (z-10) */}
+        <div className="absolute left-0 right-0 top-full z-0 overflow-hidden rounded-b-lg">
           <div className="
             -translate-y-full group-hover:translate-y-0 transition-transform duration-200 ease-out
             bg-gray-100 border-x border-b border-gray-200 rounded-b-lg

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -73,7 +73,7 @@ export default function IssueCard({ issue, hideLabels }: Props) {
         ref={cardRef}
         onMouseEnter={handleCardEnter}
         onMouseLeave={handleCardLeave}
-        className={`relative group bg-white rounded-lg border px-2 py-1.5 text-sm select-none transition-shadow ${
+        className={`relative group bg-white rounded-lg border px-2 py-1.5 text-sm select-none transition-shadow cursor-pointer ${
           busy ? 'opacity-40 pointer-events-none' :
           issue.state === 'closed' ? 'opacity-60 border-gray-200 hover:border-gray-300 hover:shadow-sm' :
           'border-gray-200 hover:border-gray-300 hover:shadow-sm'

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -1,7 +1,13 @@
-import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useState, useRef } from 'react';
 import type { GitHubIssue } from '../types';
 import { useAppStore } from '../store/appStore';
 import EditIssueModal from './EditIssueModal';
+
+function truncateMiddle(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 6) + '...' + text.slice(-3);
+}
 
 interface Props {
   issue: GitHubIssue;
@@ -9,20 +15,45 @@ interface Props {
   showStatus?: boolean;
 }
 
-export default function IssueCard({ issue, hideLabels, showStatus }: Props) {
+export default function IssueCard({ issue, hideLabels }: Props) {
   const { closeIssue, deleteIssue } = useAppStore();
   const [showEdit, setShowEdit] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [showBadgeTip, setShowBadgeTip] = useState(false);
+  const [calloutStyle, setCalloutStyle] = useState<React.CSSProperties | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const statusLabel = issue.labels.find(l => l.name.startsWith('s_'));
+  const statusName = statusLabel ? statusLabel.name.slice(2) : null;
+  const statusColor = statusLabel?.color ?? null;
+
+  const badgeStyle: React.CSSProperties = statusColor
+    ? { backgroundColor: `#${statusColor}28`, color: `#${statusColor}`, border: `1px solid #${statusColor}50` }
+    : { backgroundColor: '#f3f4f6', color: '#6b7280', border: '1px solid #e5e7eb' };
+
+  function handleCardEnter() {
+    timerRef.current = setTimeout(() => {
+      if (!cardRef.current) return;
+      const r = cardRef.current.getBoundingClientRect();
+      const W = 280, H = 180;
+      const style: React.CSSProperties = { position: 'fixed', width: W, zIndex: 9999 };
+      style.left = r.right + 8 + W <= window.innerWidth ? r.right + 8 : r.left - W - 8;
+      style.top = r.top + H <= window.innerHeight ? r.top : r.bottom - H;
+      setCalloutStyle(style);
+    }, 400);
+  }
+
+  function handleCardLeave() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setCalloutStyle(null);
+  }
 
   async function handleClose(e: React.MouseEvent) {
     e.stopPropagation();
     if (!confirm(`Close issue #${issue.number}?`)) return;
     setBusy(true);
-    try {
-      await closeIssue(issue.number);
-    } catch {
-      setBusy(false);
-    }
+    try { await closeIssue(issue.number); } catch { setBusy(false); }
   }
 
   async function handleDelete(e: React.MouseEvent) {
@@ -40,78 +71,60 @@ export default function IssueCard({ issue, hideLabels, showStatus }: Props) {
   return (
     <>
       <div
-        className={`group bg-white rounded-lg border p-3 text-sm select-none transition-shadow ${
+        ref={cardRef}
+        onMouseEnter={handleCardEnter}
+        onMouseLeave={handleCardLeave}
+        className={`relative group bg-white rounded-lg border px-2 py-1.5 text-sm select-none transition-shadow ${
           busy ? 'opacity-40 pointer-events-none' :
           issue.state === 'closed' ? 'opacity-60 border-gray-200 hover:border-gray-300 hover:shadow-sm' :
           'border-gray-200 hover:border-gray-300 hover:shadow-sm'
         }`}
       >
-        <div className="flex items-start justify-between gap-2 mb-1.5">
-          <div className="flex items-start gap-1.5 flex-1 min-w-0">
+        {/* Single-line title row */}
+        <div className="flex items-center gap-1.5 min-w-0">
+
+          {/* ID badge — background reflects status color; tooltip on hover */}
+          <div
+            className="relative shrink-0"
+            onMouseEnter={() => setShowBadgeTip(true)}
+            onMouseLeave={() => setShowBadgeTip(false)}
+          >
             <a
               href={issue.html_url}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="shrink-0 px-1.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500 border border-gray-200 tabular-nums leading-none mt-0.5 hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200 transition-colors"
+              onClick={e => e.stopPropagation()}
+              className="block px-1.5 py-0.5 rounded-full text-xs font-medium tabular-nums leading-none transition-colors"
+              style={badgeStyle}
             >
               #{issue.number}
             </a>
-            <span className="text-gray-900 font-medium leading-snug line-clamp-2">
-              {issue.title}
-            </span>
-          </div>
 
-          {/* Actions — visible on hover */}
-          <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-            <button
-              onClick={(e) => { e.stopPropagation(); setShowEdit(true); }}
-              title="Edit issue"
-              className="text-gray-400 hover:text-blue-500 p-0.5 rounded transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-              </svg>
-            </button>
-            <button
-              onClick={handleClose}
-              title="Close issue"
-              className="text-gray-400 hover:text-orange-500 p-0.5 rounded transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-            </button>
-            <button
-              onClick={handleDelete}
-              title="Delete issue permanently"
-              className="text-gray-400 hover:text-red-500 p-0.5 rounded transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        {showStatus && (
-          <div className="mb-1.5">
-            {issue.state === 'open' ? (
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200">
-                <span className="w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
-                Open
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 border border-green-200">
-                <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
-                Closed
-              </span>
+            {showBadgeTip && (
+              <div className="absolute bottom-full left-0 mb-1.5 z-20 bg-gray-900 text-white text-xs rounded-md px-2.5 py-2 shadow-lg whitespace-nowrap min-w-max">
+                {statusName && <div className="font-semibold mb-1">{statusName}</div>}
+                <a
+                  href={issue.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={e => e.stopPropagation()}
+                  className="text-blue-300 hover:text-blue-200 transition-colors"
+                >
+                  View on GitHub →
+                </a>
+              </div>
             )}
           </div>
-        )}
 
+          {/* Title — single line, middle-truncated */}
+          <span className="flex-1 min-w-0 overflow-hidden text-gray-900 font-medium leading-none">
+            {truncateMiddle(issue.title, 45)}
+          </span>
+        </div>
+
+        {/* Labels (only when not hidden) */}
         {!hideLabels && issue.labels.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-1.5">
+          <div className="flex flex-wrap gap-1 mt-1.5">
             {issue.labels.map((label) => (
               <span
                 key={label.id || label.name}
@@ -128,20 +141,67 @@ export default function IssueCard({ issue, hideLabels, showStatus }: Props) {
           </div>
         )}
 
+        {/* Assignees */}
         {issue.assignees.length > 0 && (
           <div className="flex gap-1 mt-1">
             {issue.assignees.map((user) => (
-              <img
-                key={user.login}
-                src={user.avatar_url}
-                alt={user.login}
-                title={user.login}
-                className="w-5 h-5 rounded-full"
-              />
+              <img key={user.login} src={user.avatar_url} alt={user.login} title={user.login} className="w-5 h-5 rounded-full" />
             ))}
           </div>
         )}
+
+        {/* Action row — absolutely positioned below the card, no layout reflow */}
+        <div className="absolute left-0 right-0 top-full z-10
+                        opacity-0 group-hover:opacity-100 transition-opacity
+                        bg-white border-x border-b border-gray-200 rounded-b-lg
+                        flex items-center justify-end gap-1 px-2 py-1 shadow-sm">
+          <button
+            onClick={e => { e.stopPropagation(); setShowEdit(true); }}
+            title="Edit issue"
+            className="text-gray-400 hover:text-blue-500 p-0.5 rounded transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+            </svg>
+          </button>
+          <button
+            onClick={handleClose}
+            title="Close issue"
+            className="text-gray-400 hover:text-orange-500 p-0.5 rounded transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+            </svg>
+          </button>
+          <button
+            onClick={handleDelete}
+            title="Delete issue permanently"
+            className="text-gray-400 hover:text-red-500 p-0.5 rounded transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
       </div>
+
+      {/* Description callout — rendered into body to escape any stacking context */}
+      {calloutStyle && createPortal(
+        <div
+          style={calloutStyle}
+          className="pointer-events-none bg-white border border-gray-200 rounded-lg shadow-xl p-3"
+        >
+          <div className="font-semibold text-gray-900 text-xs mb-1.5">{issue.title}</div>
+          {issue.body ? (
+            <div className="text-gray-500 text-xs leading-relaxed line-clamp-6 whitespace-pre-wrap break-words">
+              {issue.body}
+            </div>
+          ) : (
+            <div className="text-gray-400 text-xs italic">No description.</div>
+          )}
+        </div>,
+        document.body
+      )}
 
       {showEdit && <EditIssueModal issue={issue} onClose={() => setShowEdit(false)} />}
     </>

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -157,7 +157,7 @@ export default function IssueCard({ issue, hideLabels }: Props) {
             <button
               onClick={handleClose}
               title="Close issue"
-              className="text-orange-500 p-1 rounded-md border border-orange-200 bg-orange-50 hover:bg-orange-100 transition-colors"
+              className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -122,38 +122,19 @@ export default function IssueCard({ issue, hideLabels }: Props) {
           </div>
 
           {/* Title — single line, middle-truncated */}
-          <span className="flex-1 min-w-0 overflow-hidden text-gray-900 font-medium leading-none">
+          <span className="flex-1 min-w-0 overflow-hidden whitespace-nowrap text-gray-900 font-medium leading-none">
             {truncateMiddle(issue.title, 45)}
           </span>
+
+          {/* Assignees — inline so they never add height */}
+          {issue.assignees.length > 0 && (
+            <div className="flex shrink-0 -space-x-1">
+              {issue.assignees.map((user) => (
+                <img key={user.login} src={user.avatar_url} alt={user.login} title={user.login} className="w-4 h-4 rounded-full ring-1 ring-white" />
+              ))}
+            </div>
+          )}
         </div>
-
-        {/* Labels (only when not hidden) */}
-        {!hideLabels && issue.labels.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-1.5">
-            {issue.labels.map((label) => (
-              <span
-                key={label.id || label.name}
-                className="px-1.5 py-0.5 rounded text-xs font-medium"
-                style={{
-                  backgroundColor: `#${label.color}28`,
-                  color: `#${label.color}`,
-                  border: `1px solid #${label.color}50`,
-                }}
-              >
-                {label.name}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {/* Assignees */}
-        {issue.assignees.length > 0 && (
-          <div className="flex gap-1 mt-1">
-            {issue.assignees.map((user) => (
-              <img key={user.login} src={user.avatar_url} alt={user.login} title={user.login} className="w-5 h-5 rounded-full" />
-            ))}
-          </div>
-        )}
 
         </div>{/* end card surface */}
 


### PR DESCRIPTION
## Summary

- Cards are now always a single line: `#number` badge + middle-truncated title, no wrapping or layout shift
- Status color from the issue's `s_` label is applied to the ID badge background; hovering the badge reveals a tooltip with the status name and a GitHub link
- Action buttons (Edit / Close / Delete) appear in an absolutely-positioned row below the card on hover — no reflow of surrounding cards

## Implementation notes

- `truncateMiddle(text, 45)` truncates titles longer than 45 chars to `first 39 chars + "..." + last 3 chars`
- The action row uses `position: absolute; top: 100%` so it visually expands the card downward without affecting the CSS flow box; being a DOM child of the card div, it keeps the `group-hover` state active while hovered
- The description callout is rendered via `createPortal` into `document.body` with `position: fixed` coordinates computed from `getBoundingClientRect()` — this escapes any transform/overflow stacking context (e.g. dnd wrappers) and stays viewport-aware; it shows after a 400ms delay and is `pointer-events-none`
- `showStatus` prop is retained in the interface for backward compatibility but no longer renders a separate pill — status is encoded in the badge color instead

## Test plan

- [ ] Cards render as a single line with no title wrapping in both Grid and Kanban views
- [ ] Titles longer than ~45 characters are truncated in the middle (first portion + `...` + last 3 chars)
- [ ] The `#number` badge background matches the issue's status label color; issues with no status show a neutral gray badge
- [ ] Hovering the `#number` badge shows a tooltip with the status name (if any) and a "View on GitHub →" link that opens in a new tab
- [ ] Moving the cursor from the badge link into the tooltip keeps the tooltip visible; moving out hides it
- [ ] Hovering a card for ~400ms triggers the description callout to the right (or left if near viewport edge); it shows the full title and truncated body
- [ ] The description callout repositions vertically when the card is near the bottom of the viewport
- [ ] The action row (Edit / Close / Delete) appears below the card on hover without moving adjacent cards
- [ ] Clicking Edit opens `EditIssueModal`; clicking Close/Delete triggers the existing confirm dialogs

Closes #13