### PR TITLE
Enable drag and drop for issue cards

### DIFF
--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { DragDropContext, Droppable, Draggable, type DropResult } from '@hello-pangea/dnd';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue, GitHubMilestone } from '../types';
 import IssueCard from './IssueCard';
@@ -7,6 +8,22 @@ import CreateIssueModal from './CreateIssueModal';
 function getStatusLabel(issue: GitHubIssue): string | null {
   const label = issue.labels.find((l) => l.name.startsWith('s_'));
   return label ? label.name.slice(2) : null;
+}
+
+// Encode/decode cell droppable IDs for the kanban.
+// Format: "k:{status|none}:{milestoneNumber|none}"
+function kanbanCellId(status: string, milestoneNumber: number | null): string {
+  return `k:${status || 'none'}:${milestoneNumber ?? 'none'}`;
+}
+function parseKanbanCell(id: string): { status: string | null; milestoneNumber: number | null } {
+  const first = id.indexOf(':');
+  const last = id.lastIndexOf(':');
+  const statusPart = id.slice(first + 1, last);
+  const milestonePart = id.slice(last + 1);
+  return {
+    status: statusPart === 'none' ? null : statusPart,
+    milestoneNumber: milestonePart === 'none' ? null : Number(milestonePart),
+  };
 }
 
 interface CellKey {
@@ -26,8 +43,9 @@ function sortedMilestones(milestones: GitHubMilestone[], milestoneOrder: number[
 }
 
 export default function KanbanView() {
-  const { issues, milestones, statusLabels, layout, showClosedIssues } = useAppStore();
+  const { issues, milestones, statusLabels, layout, showClosedIssues, moveIssueInKanban } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
+  const [moveError, setMoveError] = useState<string | null>(null);
 
   // null sentinel = "No Milestone" swimlane — always last
   const groups: (GitHubMilestone | null)[] = [...sortedMilestones(milestones, layout.milestoneOrder), null];
@@ -47,66 +65,105 @@ export default function KanbanView() {
     });
   }
 
+  function handleDragEnd(result: DropResult) {
+    if (!result.destination) return;
+    const { draggableId, source, destination } = result;
+    if (source.droppableId === destination.droppableId && source.index === destination.index) return;
+
+    const issueNumber = Number(draggableId.slice(2));
+    const src = parseKanbanCell(source.droppableId);
+    const dst = parseKanbanCell(destination.droppableId);
+    moveIssueInKanban(issueNumber, src.status, dst.status, src.milestoneNumber, dst.milestoneNumber)
+      .catch((err) => {
+        setMoveError(err instanceof Error ? err.message : 'Failed to move issue');
+        setTimeout(() => setMoveError(null), 4000);
+      });
+  }
+
   return (
     <>
-      <div className="flex-1 overflow-auto h-full">
-        <table className="border-collapse">
-          <thead>
-            <tr>
-              {cols.map((status) => (
-                <th
-                  key={status || 'no-status'}
-                  className="sticky top-0 z-20 bg-green-50 border border-gray-200 px-4 py-3 text-sm font-semibold text-green-900 text-center w-72 min-w-72 whitespace-nowrap"
-                >
-                  {status || <span className="text-green-400 font-normal italic">No Status</span>}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {groups.map((milestone) => (
-              <>
-                <tr key={`${milestone?.number ?? 'no-milestone'}-header`}>
-                  <td
-                    colSpan={cols.length}
-                    className="sticky left-0 bg-purple-50 border border-gray-200 px-4 py-2 text-xs font-semibold text-purple-900 uppercase tracking-wide"
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <div className="flex-1 overflow-auto h-full">
+          <table className="border-collapse">
+            <thead>
+              <tr>
+                {cols.map((status) => (
+                  <th
+                    key={status || 'no-status'}
+                    className="sticky top-0 z-20 bg-green-50 border border-gray-200 px-4 py-3 text-sm font-semibold text-green-900 text-center w-72 min-w-72 whitespace-nowrap"
                   >
-                    {milestone
-                      ? milestone.title
-                      : <span className="text-purple-400 font-normal italic normal-case tracking-normal">No Milestone</span>}
-                  </td>
-                </tr>
+                    {status || <span className="text-green-400 font-normal italic">No Status</span>}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((milestone) => (
+                <>
+                  <tr key={`${milestone?.number ?? 'no-milestone'}-header`}>
+                    <td
+                      colSpan={cols.length}
+                      className="sticky left-0 bg-purple-50 border border-gray-200 px-4 py-2 text-xs font-semibold text-purple-900 uppercase tracking-wide"
+                    >
+                      {milestone
+                        ? milestone.title
+                        : <span className="text-purple-400 font-normal italic normal-case tracking-normal">No Wave</span>}
+                    </td>
+                  </tr>
 
-                <tr key={`${milestone?.number ?? 'no-milestone'}-cards`}>
-                  {cols.map((status) => {
-                    const milestoneNumber = milestone?.number ?? null;
-                    const items = cellIssues(milestoneNumber, status);
-                    return (
-                      <td
-                        key={status || 'no-status'}
-                        className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72"
-                      >
-                        <div className="flex flex-col gap-2 min-h-16">
-                          {items.map((issue) => (
-                            <IssueCard key={issue.number} issue={issue} hideLabels showStatus />
-                          ))}
-                          <button
-                            onClick={() => setCreateCell({ milestoneNumber, statusLabel: status })}
-                            className="mt-auto w-full text-xs text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-green-300 transition-colors flex items-center justify-center gap-1"
-                          >
-                            <span className="text-sm font-medium leading-none">+</span>
-                            Add issue
-                          </button>
-                        </div>
-                      </td>
-                    );
-                  })}
-                </tr>
-              </>
-            ))}
-          </tbody>
-        </table>
-      </div>
+                  <tr key={`${milestone?.number ?? 'no-milestone'}-cards`}>
+                    {cols.map((status) => {
+                      const milestoneNumber = milestone?.number ?? null;
+                      const items = cellIssues(milestoneNumber, status);
+                      return (
+                        <td
+                          key={status || 'no-status'}
+                          className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72"
+                        >
+                          <Droppable droppableId={kanbanCellId(status, milestoneNumber)} type="CARD">
+                            {(provided, snapshot) => (
+                              <div
+                                ref={provided.innerRef}
+                                {...provided.droppableProps}
+                                className={`flex flex-col gap-2 min-h-16 rounded transition-colors ${
+                                  snapshot.isDraggingOver ? 'bg-green-50/60' : ''
+                                }`}
+                              >
+                                {items.map((issue, idx) => (
+                                  <Draggable key={issue.number} draggableId={`i:${issue.number}`} index={idx}>
+                                    {(provided, snapshot) => (
+                                      <div
+                                        ref={provided.innerRef}
+                                        {...provided.draggableProps}
+                                        {...provided.dragHandleProps}
+                                        className={`transition-opacity ${snapshot.isDragging ? 'opacity-75 rotate-1 shadow-lg' : ''}`}
+                                      >
+                                        <IssueCard key={issue.number} issue={issue} hideLabels showStatus />
+                                      </div>
+                                    )}
+                                  </Draggable>
+                                ))}
+                                {provided.placeholder}
+                                <button
+                                  onClick={() => setCreateCell({ milestoneNumber, statusLabel: status })}
+                                  className="mt-auto w-full text-xs text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-green-300 transition-colors flex items-center justify-center gap-1"
+                                >
+                                  <span className="text-sm font-medium leading-none">+</span>
+                                  Add issue
+                                </button>
+                              </div>
+                            )}
+                          </Droppable>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                </>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DragDropContext>
 
       {createCell && (
         <CreateIssueModal
@@ -114,6 +171,12 @@ export default function KanbanView() {
           defaultStatusLabel={createCell.statusLabel}
           onClose={() => setCreateCell(null)}
         />
+      )}
+
+      {moveError && (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-red-600 text-white text-sm px-4 py-2.5 rounded-lg shadow-lg z-50">
+          {moveError}
+        </div>
       )}
     </>
   );

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -149,7 +149,7 @@ export default function KanbanView() {
                                   className="mt-auto w-full text-xs text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-green-300 transition-colors flex items-center justify-center gap-1"
                                 >
                                   <span className="text-sm font-medium leading-none">+</span>
-                                  Add issue
+                                  New Issue
                                 </button>
                               </div>
                             )}

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -273,10 +273,7 @@ export default function StoryMap() {
                       </Draggable>
                     ))}
                     {provided.placeholder}
-                    <th className="sticky top-0 z-20 bg-gray-50 border border-gray-200 px-4 py-3 text-sm font-semibold text-gray-500 text-center w-72 min-w-72 whitespace-nowrap">
-                      No Epic
-                    </th>
-                    <th className="sticky top-0 z-20 bg-white border border-gray-200 px-2 py-2 w-44 min-w-44">
+                    <th className="sticky top-0 z-20 bg-gray-50 border border-gray-200 px-2 py-2 text-sm font-semibold text-gray-500 text-center w-72 min-w-72">
                       {addingEpic ? (
                         <form onSubmit={handleCreateEpic} className="flex items-center gap-1">
                           <input
@@ -290,13 +287,15 @@ export default function StoryMap() {
                           <button type="button" onClick={() => { setAddingEpic(false); setNewEpicTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
                         </form>
                       ) : (
-                        <button
-                          onClick={() => setAddingEpic(true)}
-                          className="w-full text-xs text-blue-400 hover:text-blue-600 hover:bg-blue-50 rounded py-1 px-2 transition-colors flex items-center gap-1"
-                        >
-                          <span className="text-sm font-medium leading-none">+</span>
-                          New Epic
-                        </button>
+                        <div className="flex items-center justify-between px-2">
+                          <span className="text-gray-500">No Epic</span>
+                          <button
+                            onClick={() => setAddingEpic(true)}
+                            className="text-xs text-blue-400 hover:text-blue-600 hover:bg-blue-100 rounded px-1.5 py-0.5 transition-colors"
+                          >
+                            + New Epic
+                          </button>
+                        </div>
                       )}
                     </th>
                   </tr>
@@ -351,8 +350,30 @@ export default function StoryMap() {
 
                   {/* "No Wave" row — always last, not draggable */}
                   <tr key="no-wave">
-                    <th className="sticky left-0 z-10 bg-purple-50 border border-gray-200 px-3 py-2 text-xs font-semibold text-purple-900 text-right whitespace-nowrap align-top pt-3">
-                      <span className="text-purple-400 font-normal italic">No Wave</span>
+                    <th className="sticky left-0 z-10 bg-purple-50 border border-gray-200 px-2 py-2 text-xs font-semibold text-purple-900 text-right whitespace-nowrap align-top pt-3">
+                      {addingWave ? (
+                        <form onSubmit={handleCreateWave} className="flex items-center gap-1">
+                          <input
+                            autoFocus
+                            value={newWaveTitle}
+                            onChange={(e) => setNewWaveTitle(e.target.value)}
+                            placeholder="Wave name…"
+                            className="flex-1 min-w-0 border border-purple-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-purple-400"
+                          />
+                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-purple-600 hover:text-purple-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
+                          <button type="button" onClick={() => { setAddingWave(false); setNewWaveTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
+                        </form>
+                      ) : (
+                        <div className="flex items-center justify-end gap-2">
+                          <span className="text-purple-400 font-normal italic">No Wave</span>
+                          <button
+                            onClick={() => setAddingWave(true)}
+                            className="text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-100 rounded px-1.5 py-0.5 transition-colors not-italic font-normal"
+                          >
+                            + New Wave
+                          </button>
+                        </div>
+                      )}
                     </th>
                     {cols.map((project) => (
                       <td key={project.id} className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72">
@@ -372,35 +393,6 @@ export default function StoryMap() {
                         addColor="gray"
                       />
                     </td>
-                    <td className="border-0" />
-                  </tr>
-
-                  {/* "+ New Wave" row */}
-                  <tr key="add-wave">
-                    <th className="sticky left-0 z-10 bg-white border border-gray-200 px-2 py-2">
-                      {addingWave ? (
-                        <form onSubmit={handleCreateWave} className="flex items-center gap-1">
-                          <input
-                            autoFocus
-                            value={newWaveTitle}
-                            onChange={(e) => setNewWaveTitle(e.target.value)}
-                            placeholder="Wave name…"
-                            className="flex-1 min-w-0 border border-purple-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-purple-400"
-                          />
-                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-purple-600 hover:text-purple-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
-                          <button type="button" onClick={() => { setAddingWave(false); setNewWaveTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
-                        </form>
-                      ) : (
-                        <button
-                          onClick={() => setAddingWave(true)}
-                          className="w-full text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-50 rounded py-1 px-2 transition-colors flex items-center justify-end gap-1"
-                        >
-                          <span className="text-sm font-medium leading-none">+</span>
-                          New Wave
-                        </button>
-                      )}
-                    </th>
-                    <td colSpan={cols.length + 2} className="border border-gray-100 bg-white" />
                   </tr>
                 </tbody>
               )}

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -28,18 +28,87 @@ function sortedMilestones(milestones: GitHubMilestone[], milestoneOrder: number[
   });
 }
 
+// Encode/decode cell droppable IDs for the grid.
+// Format: "g:{projectId|none}:{milestoneNumber|none}"
+// Using lastIndexOf so projectId (base-64, no colons) is safely sliced.
+function cellId(projectId: string, milestoneNumber: number | null): string {
+  return `g:${projectId || 'none'}:${milestoneNumber ?? 'none'}`;
+}
+function parseCell(id: string): { projectId: string; milestoneNumber: number | null } {
+  const first = id.indexOf(':');
+  const last = id.lastIndexOf(':');
+  const projectPart = id.slice(first + 1, last);
+  const milestonePart = id.slice(last + 1);
+  return {
+    projectId: projectPart === 'none' ? '' : projectPart,
+    milestoneNumber: milestonePart === 'none' ? null : Number(milestonePart),
+  };
+}
+
 interface CellKey {
   projectId: string;
   milestoneNumber: number | null;
 }
 
+interface CardCellProps {
+  droppableId: string;
+  items: GitHubIssue[];
+  onAdd: () => void;
+  addColor?: 'blue' | 'gray';
+}
+
+function CardCell({ droppableId, items, onAdd, addColor = 'blue' }: CardCellProps) {
+  const hoverCls = addColor === 'gray'
+    ? 'hover:text-gray-600 hover:bg-gray-100 hover:border-gray-300'
+    : 'hover:text-blue-500 hover:bg-blue-50 hover:border-blue-300';
+  return (
+    <Droppable droppableId={droppableId} type="CARD">
+      {(provided, snapshot) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.droppableProps}
+          className={`flex flex-col gap-2 min-h-16 rounded transition-colors ${
+            snapshot.isDraggingOver ? 'bg-blue-50/60' : ''
+          }`}
+        >
+          {items.map((issue, idx) => (
+            <Draggable key={issue.number} draggableId={`i:${issue.number}`} index={idx}>
+              {(provided, snapshot) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.draggableProps}
+                  {...provided.dragHandleProps}
+                  className={`transition-opacity ${snapshot.isDragging ? 'opacity-75 rotate-1 shadow-lg' : ''}`}
+                >
+                  <IssueCard issue={issue} hideLabels showStatus />
+                </div>
+              )}
+            </Draggable>
+          ))}
+          {provided.placeholder}
+          <button
+            onClick={onAdd}
+            className={`mt-auto w-full text-xs text-gray-400 ${hoverCls} rounded-lg py-1.5 border border-dashed border-gray-200 transition-colors flex items-center justify-center gap-1`}
+          >
+            <span className="text-sm font-medium leading-none">+</span>
+            Add issue
+          </button>
+        </div>
+      )}
+    </Droppable>
+  );
+}
+
 export default function StoryMap() {
-  const { issues, projects, projectIssues, milestones, layout, reorderProjects, reorderMilestones, showClosedIssues } = useAppStore();
+  const {
+    issues, projects, projectIssues, milestones, layout,
+    reorderProjects, reorderMilestones, moveIssueInGrid, showClosedIssues,
+  } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
+  const [moveError, setMoveError] = useState<string | null>(null);
 
   const cols = sortedProjects(projects, layout.epicOrder);
   const orderedMilestones = sortedMilestones(milestones, layout.milestoneOrder);
-
   const visibleIssues = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
 
   function cellIssues(projectId: string, milestoneNumber: number | null): GitHubIssue[] {
@@ -64,12 +133,28 @@ export default function StoryMap() {
   }
 
   function handleDragEnd(result: DropResult) {
-    if (!result.destination || result.source.index === result.destination.index) return;
-    if (result.source.droppableId === 'columns') {
-      reorderProjects(result.source.index, result.destination.index);
-    } else if (result.source.droppableId === 'rows') {
-      reorderMilestones(result.source.index, result.destination.index);
+    if (!result.destination) return;
+    const { draggableId, source, destination } = result;
+
+    if (source.droppableId === 'columns') {
+      if (source.index !== destination.index) reorderProjects(source.index, destination.index);
+      return;
     }
+    if (source.droppableId === 'rows') {
+      if (source.index !== destination.index) reorderMilestones(source.index, destination.index);
+      return;
+    }
+
+    // Issue card drop
+    if (source.droppableId === destination.droppableId && source.index === destination.index) return;
+    const issueNumber = Number(draggableId.slice(2));
+    const src = parseCell(source.droppableId);
+    const dst = parseCell(destination.droppableId);
+    moveIssueInGrid(issueNumber, src.projectId, dst.projectId, src.milestoneNumber, dst.milestoneNumber)
+      .catch((err) => {
+        setMoveError(err instanceof Error ? err.message : 'Failed to move issue');
+        setTimeout(() => setMoveError(null), 4000);
+      });
   }
 
   if (cols.length === 0) {
@@ -89,7 +174,7 @@ export default function StoryMap() {
           <table className="border-collapse">
             {/* Column headers — draggable horizontally */}
             <thead>
-              <Droppable droppableId="columns" direction="horizontal">
+              <Droppable droppableId="columns" direction="horizontal" type="COLUMN">
                 {(provided) => (
                   <tr ref={provided.innerRef} {...provided.droppableProps}>
                     <th className="sticky left-0 top-0 z-30 bg-white border border-gray-200 w-36 min-w-36" />
@@ -120,7 +205,7 @@ export default function StoryMap() {
             </thead>
 
             {/* Milestone rows — draggable vertically */}
-            <Droppable droppableId="rows">
+            <Droppable droppableId="rows" type="ROW">
               {(provided) => (
                 <tbody ref={provided.innerRef} {...provided.droppableProps}>
                   {orderedMilestones.map((milestone, index) => (
@@ -140,101 +225,53 @@ export default function StoryMap() {
                             <span className="text-purple-300 mr-1 text-xs">⠿</span>
                             {milestone.title}
                           </th>
-                          {cols.map((project) => {
-                            const items = cellIssues(project.id, milestone.number);
-                            return (
-                              <td
-                                key={project.id}
-                                className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72"
-                              >
-                                <div className="flex flex-col gap-2 min-h-16">
-                                  {items.map((issue) => (
-                                    <IssueCard key={issue.number} issue={issue} hideLabels showStatus />
-                                  ))}
-                                  <button
-                                    onClick={() => setCreateCell({ projectId: project.id, milestoneNumber: milestone.number })}
-                                    className="mt-auto w-full text-xs text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-blue-300 transition-colors flex items-center justify-center gap-1"
-                                  >
-                                    <span className="text-sm font-medium leading-none">+</span>
-                                    Add issue
-                                  </button>
-                                </div>
-                              </td>
-                            );
-                          })}
-                          {/* No Project cell */}
-                          {(() => {
-                            const items = noProjectCellIssues(milestone.number);
-                            return (
-                              <td className="border border-gray-200 align-top p-2 bg-gray-50/50 w-72 min-w-72">
-                                <div className="flex flex-col gap-2 min-h-16">
-                                  {items.map((issue) => (
-                                    <IssueCard key={issue.number} issue={issue} hideLabels showStatus />
-                                  ))}
-                                  <button
-                                    onClick={() => setCreateCell({ projectId: '', milestoneNumber: milestone.number })}
-                                    className="mt-auto w-full text-xs text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-blue-300 transition-colors flex items-center justify-center gap-1"
-                                  >
-                                    <span className="text-sm font-medium leading-none">+</span>
-                                    Add issue
-                                  </button>
-                                </div>
-                              </td>
-                            );
-                          })()}
+                          {cols.map((project) => (
+                            <td key={project.id} className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72">
+                              <CardCell
+                                droppableId={cellId(project.id, milestone.number)}
+                                items={cellIssues(project.id, milestone.number)}
+                                onAdd={() => setCreateCell({ projectId: project.id, milestoneNumber: milestone.number })}
+                              />
+                            </td>
+                          ))}
+                          {/* No Epic cell */}
+                          <td className="border border-gray-200 align-top p-2 bg-gray-50/50 w-72 min-w-72">
+                            <CardCell
+                              droppableId={cellId('', milestone.number)}
+                              items={noProjectCellIssues(milestone.number)}
+                              onAdd={() => setCreateCell({ projectId: '', milestoneNumber: milestone.number })}
+                              addColor="gray"
+                            />
+                          </td>
                         </tr>
                       )}
                     </Draggable>
                   ))}
                   {provided.placeholder}
 
-                  {/* "No Milestone" row — always last, not draggable */}
-                  <tr key="no-milestone">
+                  {/* "No Wave" row — always last, not draggable */}
+                  <tr key="no-wave">
                     <th className="sticky left-0 z-10 bg-purple-50 border border-gray-200 px-3 py-2 text-xs font-semibold text-purple-900 text-right whitespace-nowrap align-top pt-3">
                       <span className="text-purple-400 font-normal italic">No Wave</span>
                     </th>
-                    {cols.map((project) => {
-                      const items = cellIssues(project.id, null);
-                      return (
-                        <td
-                          key={project.id}
-                          className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72"
-                        >
-                          <div className="flex flex-col gap-2 min-h-16">
-                            {items.map((issue) => (
-                              <IssueCard key={issue.number} issue={issue} hideLabels showStatus />
-                            ))}
-                            <button
-                              onClick={() => setCreateCell({ projectId: project.id, milestoneNumber: null })}
-                              className="mt-auto w-full text-xs text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-blue-300 transition-colors flex items-center justify-center gap-1"
-                            >
-                              <span className="text-sm font-medium leading-none">+</span>
-                              Add issue
-                            </button>
-                          </div>
-                        </td>
-                      );
-                    })}
-                    {/* No Project cell — No Milestone row */}
-                    {(() => {
-                      const items = noProjectCellIssues(null);
-                      return (
-                        <td className="border border-gray-200 align-top p-2 bg-gray-50/50 w-72 min-w-72">
-                          <div className="flex flex-col gap-2 min-h-16">
-                            {items.map((issue) => (
-                              <IssueCard key={issue.number} issue={issue} hideLabels showStatus />
-                            ))}
-                            <button
-                              onClick={() => setCreateCell({ projectId: '', milestoneNumber: null })}
-                              className="mt-auto w-full text-xs text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-blue-300 transition-colors flex items-center justify-center gap-1"
-                            >
-                              <span className="text-sm font-medium leading-none">+</span>
-                              Add issue
-                            </button>
-                          </div>
-                        </td>
-                      );
-                    })()}
+                    {cols.map((project) => (
+                      <td key={project.id} className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72">
+                        <CardCell
+                          droppableId={cellId(project.id, null)}
+                          items={cellIssues(project.id, null)}
+                          onAdd={() => setCreateCell({ projectId: project.id, milestoneNumber: null })}
+                        />
+                      </td>
+                    ))}
+                    {/* No Epic / No Wave corner */}
+                    <td className="border border-gray-200 align-top p-2 bg-gray-50/50 w-72 min-w-72">
+                      <CardCell
+                        droppableId={cellId('', null)}
+                        items={noProjectCellIssues(null)}
+                        onAdd={() => setCreateCell({ projectId: '', milestoneNumber: null })}
+                        addColor="gray"
+                      />
+                    </td>
                   </tr>
                 </tbody>
               )}
@@ -249,6 +286,12 @@ export default function StoryMap() {
           defaultMilestoneNumber={createCell.milestoneNumber ?? undefined}
           onClose={() => setCreateCell(null)}
         />
+      )}
+
+      {moveError && (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-red-600 text-white text-sm px-4 py-2.5 rounded-lg shadow-lg z-50">
+          {moveError}
+        </div>
       )}
     </>
   );

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -91,7 +91,7 @@ function CardCell({ droppableId, items, onAdd, addColor = 'blue' }: CardCellProp
             className={`mt-auto w-full text-xs text-gray-400 ${hoverCls} rounded-lg py-1.5 border border-dashed border-gray-200 transition-colors flex items-center justify-center gap-1`}
           >
             <span className="text-sm font-medium leading-none">+</span>
-            Add issue
+            New Issue
           </button>
         </div>
       )}

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -368,7 +368,7 @@ export default function StoryMap() {
                           <span className="text-gray-400 font-normal italic">No Wave</span>
                           <button
                             onClick={() => setAddingWave(true)}
-                            className="text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-100 rounded px-1.5 py-0.5 transition-colors not-italic font-normal"
+                            className="text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-100 rounded px-1.5 py-0.5 transition-colors not-italic font-semibold"
                           >
                             + New Wave
                           </button>

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -358,9 +358,9 @@ export default function StoryMap() {
                             value={newWaveTitle}
                             onChange={(e) => setNewWaveTitle(e.target.value)}
                             placeholder="Wave name…"
-                            className="flex-1 min-w-0 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-gray-400"
+                            className="flex-1 min-w-0 border border-purple-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-purple-400"
                           />
-                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-gray-600 hover:text-gray-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
+                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-purple-600 hover:text-purple-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
                           <button type="button" onClick={() => { setAddingWave(false); setNewWaveTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
                         </form>
                       ) : (
@@ -368,7 +368,7 @@ export default function StoryMap() {
                           <span className="text-gray-400 font-normal italic">No Wave</span>
                           <button
                             onClick={() => setAddingWave(true)}
-                            className="text-xs text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded px-1.5 py-0.5 transition-colors not-italic font-normal"
+                            className="text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-100 rounded px-1.5 py-0.5 transition-colors not-italic font-normal"
                           >
                             + New Wave
                           </button>

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -350,7 +350,7 @@ export default function StoryMap() {
 
                   {/* "No Wave" row — always last, not draggable */}
                   <tr key="no-wave">
-                    <th className="sticky left-0 z-10 bg-purple-50 border border-gray-200 px-2 py-2 text-xs font-semibold text-purple-900 text-right whitespace-nowrap align-top pt-3">
+                    <th className="sticky left-0 z-10 bg-gray-50 border border-gray-200 px-2 py-2 text-xs font-semibold text-gray-500 text-right whitespace-nowrap align-top pt-3">
                       {addingWave ? (
                         <form onSubmit={handleCreateWave} className="flex items-center gap-1">
                           <input
@@ -358,17 +358,17 @@ export default function StoryMap() {
                             value={newWaveTitle}
                             onChange={(e) => setNewWaveTitle(e.target.value)}
                             placeholder="Wave name…"
-                            className="flex-1 min-w-0 border border-purple-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-purple-400"
+                            className="flex-1 min-w-0 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-gray-400"
                           />
-                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-purple-600 hover:text-purple-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
+                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-gray-600 hover:text-gray-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
                           <button type="button" onClick={() => { setAddingWave(false); setNewWaveTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
                         </form>
                       ) : (
                         <div className="flex items-center justify-end gap-2">
-                          <span className="text-purple-400 font-normal italic">No Wave</span>
+                          <span className="text-gray-400 font-normal italic">No Wave</span>
                           <button
                             onClick={() => setAddingWave(true)}
-                            className="text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-100 rounded px-1.5 py-0.5 transition-colors not-italic font-normal"
+                            className="text-xs text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded px-1.5 py-0.5 transition-colors not-italic font-normal"
                           >
                             + New Wave
                           </button>

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -103,9 +103,53 @@ export default function StoryMap() {
   const {
     issues, projects, projectIssues, milestones, layout,
     reorderProjects, reorderMilestones, moveIssueInGrid, showClosedIssues,
+    createProject, createMilestone,
   } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
+
+  const [addingEpic, setAddingEpic] = useState(false);
+  const [newEpicTitle, setNewEpicTitle] = useState('');
+  const [epicSaving, setEpicSaving] = useState(false);
+
+  const [addingWave, setAddingWave] = useState(false);
+  const [newWaveTitle, setNewWaveTitle] = useState('');
+  const [waveSaving, setWaveSaving] = useState(false);
+
+  function showError(msg: string) {
+    setMoveError(msg);
+    setTimeout(() => setMoveError(null), 4000);
+  }
+
+  async function handleCreateEpic(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newEpicTitle.trim()) return;
+    setEpicSaving(true);
+    try {
+      await createProject(newEpicTitle.trim(), '');
+      setNewEpicTitle('');
+      setAddingEpic(false);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to create epic');
+    } finally {
+      setEpicSaving(false);
+    }
+  }
+
+  async function handleCreateWave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newWaveTitle.trim()) return;
+    setWaveSaving(true);
+    try {
+      await createMilestone(newWaveTitle.trim(), '');
+      setNewWaveTitle('');
+      setAddingWave(false);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to create wave');
+    } finally {
+      setWaveSaving(false);
+    }
+  }
 
   const cols = sortedProjects(projects, layout.epicOrder);
   const orderedMilestones = sortedMilestones(milestones, layout.milestoneOrder);
@@ -159,10 +203,43 @@ export default function StoryMap() {
 
   if (cols.length === 0) {
     return (
-      <div className="flex items-center justify-center h-full text-gray-400 text-sm">
-        No epics found. Use{' '}
-        <span className="font-mono mx-1 bg-gray-100 px-1 rounded">Epics</span>
-        {' '}to create one.
+      <div className="flex flex-col items-center justify-center h-full gap-3">
+        <p className="text-gray-400 text-sm">No epics yet.</p>
+        {addingEpic ? (
+          <form onSubmit={handleCreateEpic} className="flex items-center gap-2">
+            <input
+              autoFocus
+              value={newEpicTitle}
+              onChange={(e) => setNewEpicTitle(e.target.value)}
+              placeholder="Epic name…"
+              className="border border-blue-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            />
+            <button
+              type="submit"
+              disabled={epicSaving || !newEpicTitle.trim()}
+              className="px-3 py-1.5 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {epicSaving ? 'Creating…' : 'Create'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setAddingEpic(false); setNewEpicTitle(''); }}
+              className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors"
+            >
+              Cancel
+            </button>
+          </form>
+        ) : (
+          <button
+            onClick={() => setAddingEpic(true)}
+            className="text-sm text-blue-600 hover:text-blue-800 px-4 py-2 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+          >
+            + New Epic
+          </button>
+        )}
+        {moveError && (
+          <p className="text-red-500 text-sm">{moveError}</p>
+        )}
       </div>
     );
   }
@@ -198,6 +275,29 @@ export default function StoryMap() {
                     {provided.placeholder}
                     <th className="sticky top-0 z-20 bg-gray-50 border border-gray-200 px-4 py-3 text-sm font-semibold text-gray-500 text-center w-72 min-w-72 whitespace-nowrap">
                       No Epic
+                    </th>
+                    <th className="sticky top-0 z-20 bg-white border border-gray-200 px-2 py-2 w-44 min-w-44">
+                      {addingEpic ? (
+                        <form onSubmit={handleCreateEpic} className="flex items-center gap-1">
+                          <input
+                            autoFocus
+                            value={newEpicTitle}
+                            onChange={(e) => setNewEpicTitle(e.target.value)}
+                            placeholder="Epic name…"
+                            className="flex-1 min-w-0 border border-blue-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400"
+                          />
+                          <button type="submit" disabled={epicSaving || !newEpicTitle.trim()} className="text-blue-600 hover:text-blue-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
+                          <button type="button" onClick={() => { setAddingEpic(false); setNewEpicTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
+                        </form>
+                      ) : (
+                        <button
+                          onClick={() => setAddingEpic(true)}
+                          className="w-full text-xs text-blue-400 hover:text-blue-600 hover:bg-blue-50 rounded py-1 px-2 transition-colors flex items-center gap-1"
+                        >
+                          <span className="text-sm font-medium leading-none">+</span>
+                          New Epic
+                        </button>
+                      )}
                     </th>
                   </tr>
                 )}
@@ -272,6 +372,35 @@ export default function StoryMap() {
                         addColor="gray"
                       />
                     </td>
+                    <td className="border-0" />
+                  </tr>
+
+                  {/* "+ New Wave" row */}
+                  <tr key="add-wave">
+                    <th className="sticky left-0 z-10 bg-white border border-gray-200 px-2 py-2">
+                      {addingWave ? (
+                        <form onSubmit={handleCreateWave} className="flex items-center gap-1">
+                          <input
+                            autoFocus
+                            value={newWaveTitle}
+                            onChange={(e) => setNewWaveTitle(e.target.value)}
+                            placeholder="Wave name…"
+                            className="flex-1 min-w-0 border border-purple-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-purple-400"
+                          />
+                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="text-purple-600 hover:text-purple-800 disabled:opacity-40 px-1 text-base leading-none">✓</button>
+                          <button type="button" onClick={() => { setAddingWave(false); setNewWaveTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">✕</button>
+                        </form>
+                      ) : (
+                        <button
+                          onClick={() => setAddingWave(true)}
+                          className="w-full text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-50 rounded py-1 px-2 transition-colors flex items-center justify-end gap-1"
+                        >
+                          <span className="text-sm font-medium leading-none">+</span>
+                          New Wave
+                        </button>
+                      )}
+                    </th>
+                    <td colSpan={cols.length + 2} className="border border-gray-100 bg-white" />
                   </tr>
                 </tbody>
               )}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -53,6 +53,20 @@ interface AppState {
   removeIssueFromProject: (issueNodeId: string, projectId: string) => Promise<void>;
   reorderProjects: (fromIndex: number, toIndex: number) => void;
   reorderMilestones: (fromIndex: number, toIndex: number) => void;
+  moveIssueInGrid: (
+    issueNumber: number,
+    fromProjectId: string,
+    toProjectId: string,
+    fromMilestoneNumber: number | null,
+    toMilestoneNumber: number | null,
+  ) => Promise<void>;
+  moveIssueInKanban: (
+    issueNumber: number,
+    fromStatus: string | null,
+    toStatus: string | null,
+    fromMilestoneNumber: number | null,
+    toMilestoneNumber: number | null,
+  ) => Promise<void>;
 }
 
 const emptyLayout: StoryMapLayout = { epicOrder: [], milestoneOrder: [], storyOrder: { backlog: [] } };
@@ -636,5 +650,128 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newLayout = { ...layout, milestoneOrder };
     set({ layout: newLayout });
     saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
+  },
+
+  moveIssueInGrid: async (issueNumber, fromProjectId, toProjectId, fromMilestoneNumber, toMilestoneNumber) => {
+    const { token, owner, repo, issues, projectIssues, milestones } = get();
+    const issue = issues.find((i) => i.number === issueNumber);
+    if (!issue) return;
+
+    const snapIssues = issues;
+    const snapProjectIssues = projectIssues;
+
+    // Optimistic update — milestone and project membership
+    const newMilestone = toMilestoneNumber === null
+      ? null
+      : milestones.find((m) => m.number === toMilestoneNumber) ?? null;
+
+    let updatedProjectIssues = { ...projectIssues };
+    if (fromProjectId !== toProjectId) {
+      if (fromProjectId) {
+        updatedProjectIssues = {
+          ...updatedProjectIssues,
+          [fromProjectId]: (updatedProjectIssues[fromProjectId] ?? []).filter((n) => n !== issueNumber),
+        };
+      }
+      if (toProjectId) {
+        updatedProjectIssues = {
+          ...updatedProjectIssues,
+          [toProjectId]: [issueNumber, ...(updatedProjectIssues[toProjectId] ?? [])],
+        };
+      }
+    }
+
+    set({
+      issues: issues.map((i) => i.number === issueNumber ? { ...i, milestone: newMilestone } : i),
+      projectIssues: updatedProjectIssues,
+    });
+
+    try {
+      if (fromProjectId !== toProjectId) {
+        if (fromProjectId) {
+          const data = await gql<{
+            node: { items: { nodes: Array<{ id: string; content: { id: string } | null }> } } | null;
+          }>(token, `
+            query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100) {
+                    nodes { id content { ... on Issue { id } } }
+                  }
+                }
+              }
+            }
+          `, { projectId: fromProjectId });
+          const item = data.node?.items.nodes.find((n) => n.content?.id === issue.node_id);
+          if (item) {
+            await gql(token, `
+              mutation($projectId: ID!, $itemId: ID!) {
+                deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) { deletedItemId }
+              }
+            `, { projectId: fromProjectId, itemId: item.id });
+          }
+        }
+        if (toProjectId) {
+          await gql(token, `
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } }
+            }
+          `, { projectId: toProjectId, contentId: issue.node_id });
+        }
+      }
+      if (fromMilestoneNumber !== toMilestoneNumber) {
+        const octokit = new Octokit({ auth: token });
+        await octokit.rest.issues.update({
+          owner, repo, issue_number: issueNumber,
+          milestone: toMilestoneNumber,
+        });
+      }
+    } catch (err) {
+      set({ issues: snapIssues, projectIssues: snapProjectIssues });
+      throw err;
+    }
+  },
+
+  moveIssueInKanban: async (issueNumber, fromStatus, toStatus, fromMilestoneNumber, toMilestoneNumber) => {
+    const { token, owner, repo, issues, milestones } = get();
+    const issue = issues.find((i) => i.number === issueNumber);
+    if (!issue) return;
+
+    const snapIssues = issues;
+
+    const baseLabels = issue.labels.filter((l) => !l.name.startsWith('s_'));
+    const newLabels = toStatus
+      ? [...baseLabels, { id: 0, name: `s_${toStatus}`, color: '0e8a16' }]
+      : baseLabels;
+
+    const newMilestone = toMilestoneNumber === null
+      ? null
+      : milestones.find((m) => m.number === toMilestoneNumber) ?? null;
+
+    set({
+      issues: issues.map((i) =>
+        i.number === issueNumber ? { ...i, labels: newLabels, milestone: newMilestone } : i
+      ),
+    });
+
+    try {
+      const octokit = new Octokit({ auth: token });
+      if (fromStatus !== toStatus) {
+        if (toStatus) await ensureLabel(octokit, owner, repo, `s_${toStatus}`, '0e8a16');
+        await octokit.rest.issues.setLabels({
+          owner, repo, issue_number: issueNumber,
+          labels: newLabels.map((l) => l.name),
+        });
+      }
+      if (fromMilestoneNumber !== toMilestoneNumber) {
+        await octokit.rest.issues.update({
+          owner, repo, issue_number: issueNumber,
+          milestone: toMilestoneNumber,
+        });
+      }
+    } catch (err) {
+      set({ issues: snapIssues });
+      throw err;
+    }
   },
 }));


### PR DESCRIPTION
## Summary

- Issue cards can now be dragged between cells in both the **Grid view** (Epic × Wave) and the **Kanban view** (Status × Wave), with optimistic UI updates and automatic GitHub API sync.
- Dropping a card in the Grid changes its **Epic** (via Projects V2 GraphQL mutations) and/or **Wave** (via Octokit milestone update). Dropping in Kanban changes its **status label** (`s_` prefix) and/or **Wave**.
- On API failure the UI is rolled back to its pre-drag state and a brief toast error appears at the bottom of the screen.

## Implementation notes

- **Typed droppables**: Grid uses `type="COLUMN"` / `type="ROW"` for header reordering and `type="CARD"` for issue cells, preventing cross-type drops. Kanban uses `type="CARD"` only.
- **Cell ID encoding**: `g:{projectId|none}:{milestoneNumber|none}` for Grid, `k:{status|none}:{milestoneNumber|none}` for Kanban. Both use last-colon slicing so project IDs (base64, no colons) parse safely.
- **No new dependencies**: `@hello-pangea/dnd` was already installed; only store actions and view wiring are new.
- **Kanban "No Milestone" label** was updated from "No Milestone" to "No Wave" as part of this file rewrite (matching the earlier rename in #25).
- Store actions (`moveIssueInGrid`, `moveIssueInKanban`) inline the GraphQL/Octokit calls directly rather than calling existing store methods to avoid double state updates after the optimistic patch.

## Test plan

- [ ] **Grid — same Epic, different Wave**: drag a card from one row to another → milestone updates on GitHub, card appears in correct row.
- [ ] **Grid — different Epic, same Wave**: drag a card across columns → old project membership removed, new project added on GitHub.
- [ ] **Grid — Epic and Wave both change**: drag to a completely different cell → both mutations fire.
- [ ] **Grid — drag to No Epic column**: issue is removed from its project on GitHub.
- [ ] **Grid — drag to No Wave row**: issue milestone is cleared on GitHub.
- [ ] **Kanban — change Status**: drag a card to a different column → `s_` label is swapped on GitHub.
- [ ] **Kanban — change Wave**: drag a card to a different swimlane → milestone updates on GitHub.
- [ ] **Optimistic update**: card moves instantly without waiting for API.
- [ ] **Rollback**: disconnect from network, drag a card → card snaps back and red toast appears.
- [ ] **Column / row reordering still works** in Grid view without interference from card DnD.

Closes #12