### PR TITLE
Auto generate descriptions with AI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env
 .env.local
 *.local
+.firebase

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,19 @@
 {
   "firestore": {
     "rules": "firestore.rules"
+  },
+  "hosting": {
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
   }
 }

--- a/src/components/CreateIssueModal.tsx
+++ b/src/components/CreateIssueModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
+import { generateDescription, loadGeminiSettings } from '../lib/gemini';
 
 interface Props {
   defaultProjectId?: string;
@@ -9,7 +10,7 @@ interface Props {
 }
 
 export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNumber, defaultStatusLabel, onClose }: Props) {
-  const { projects, milestones, statusLabels, createIssue } = useAppStore();
+  const { token, owner, repo, projects, milestones, statusLabels, createIssue } = useAppStore();
 
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
@@ -17,7 +18,25 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
   const [milestoneNumber, setMilestoneNumber] = useState<string>(defaultMilestoneNumber?.toString() ?? '');
   const [statusLabel, setStatusLabel] = useState(defaultStatusLabel ?? '');
   const [submitting, setSubmitting] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const [error, setError] = useState('');
+
+  const openProjects = projects.filter((p) => !p.closed);
+  const hasGeminiKey = Boolean(loadGeminiSettings().apiKey);
+
+  async function handleGenerate() {
+    if (!title.trim()) { setError('Add a title before generating.'); return; }
+    setGenerating(true);
+    setError('');
+    try {
+      const result = await generateDescription(token, owner, repo, title.trim(), body.trim());
+      setBody(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Generation failed');
+    } finally {
+      setGenerating(false);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -38,8 +57,6 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
       setSubmitting(false);
     }
   }
-
-  const openProjects = projects.filter((p) => !p.closed);
 
   return (
     <div
@@ -72,9 +89,31 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Description <span className="text-gray-400 font-normal">(optional)</span>
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Description <span className="text-gray-400 font-normal">(optional)</span>
+              </label>
+              {hasGeminiKey && (
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={generating || !title.trim()}
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-lg hover:bg-purple-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {generating ? (
+                    <>
+                      <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                      </svg>
+                      Generating…
+                    </>
+                  ) : (
+                    <>✦ Generate with AI</>
+                  )}
+                </button>
+              )}
+            </div>
             <textarea
               value={body}
               onChange={(e) => setBody(e.target.value)}

--- a/src/components/EditIssueModal.tsx
+++ b/src/components/EditIssueModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue } from '../types';
+import { generateDescription, loadGeminiSettings } from '../lib/gemini';
 
 interface Props {
   issue: GitHubIssue;
@@ -8,7 +9,7 @@ interface Props {
 }
 
 export default function EditIssueModal({ issue, onClose }: Props) {
-  const { projects, projectIssues, milestones, updateIssue, addIssueToProject, removeIssueFromProject } = useAppStore();
+  const { token, owner, repo, projects, projectIssues, milestones, updateIssue, addIssueToProject, removeIssueFromProject } = useAppStore();
 
   const [title, setTitle] = useState(issue.title);
   const [body, setBody] = useState(issue.body ?? '');
@@ -24,8 +25,24 @@ export default function EditIssueModal({ issue, onClose }: Props) {
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [generating, setGenerating] = useState(false);
 
   const openProjects = projects.filter((p) => !p.closed);
+  const hasGeminiKey = Boolean(loadGeminiSettings().apiKey);
+
+  async function handleGenerate() {
+    if (!title.trim()) { setError('Add a title before generating.'); return; }
+    setGenerating(true);
+    setError('');
+    try {
+      const result = await generateDescription(token, owner, repo, title.trim(), body.trim());
+      setBody(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Generation failed');
+    } finally {
+      setGenerating(false);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -82,9 +99,31 @@ export default function EditIssueModal({ issue, onClose }: Props) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Description <span className="text-gray-400 font-normal">(optional)</span>
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Description <span className="text-gray-400 font-normal">(optional)</span>
+              </label>
+              {hasGeminiKey && (
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={generating || !title.trim()}
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-lg hover:bg-purple-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {generating ? (
+                    <>
+                      <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                      </svg>
+                      Generating…
+                    </>
+                  ) : (
+                    <>✦ Generate with AI</>
+                  )}
+                </button>
+              )}
+            </div>
             <textarea
               value={body}
               onChange={(e) => setBody(e.target.value)}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
 import LabelsManagerModal from './LabelsManagerModal';
+import SettingsModal from './SettingsModal';
 
 export default function Header() {
   const { owner, repo, issues, fetchIssues, fetchProjects, fetchMilestones, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues } = useAppStore();
   const [showCreate, setShowCreate] = useState(false);
   const [showLabels, setShowLabels] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   return (
     <>
@@ -65,6 +67,12 @@ export default function Header() {
             {loading ? 'Syncing…' : 'Sync'}
           </button>
           <button
+            onClick={() => setShowSettings(true)}
+            className="text-sm text-gray-600 hover:text-gray-900 px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+          >
+            Settings
+          </button>
+          <button
             onClick={reset}
             className="text-sm text-gray-500 hover:text-red-600 px-3 py-1.5 rounded-lg hover:bg-red-50 transition-colors"
           >
@@ -93,6 +101,7 @@ export default function Header() {
 
       {showCreate && <CreateIssueModal onClose={() => setShowCreate(false)} />}
       {showLabels && <LabelsManagerModal onClose={() => setShowLabels(false)} />}
+      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
     </>
   );
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,9 +1,33 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
-import { loadGeminiSettings, saveGeminiSettings } from '../lib/gemini';
+import { loadGeminiSettings, saveGeminiSettings, testGeminiConnection, DEFAULT_GEMINI_MODEL } from '../lib/gemini';
 
 interface Props {
   onClose: () => void;
+}
+
+type LedState = 'idle' | 'testing' | 'success' | 'error';
+
+function Led({ state, onClick }: { state: LedState; onClick: () => void }) {
+  const colors: Record<LedState, string> = {
+    idle: 'bg-gray-300',
+    testing: 'bg-green-400 animate-pulse',
+    success: 'bg-green-500',
+    error: 'bg-red-500',
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={state === 'idle' ? 'Click to test connection' : state === 'testing' ? 'Testing…' : state === 'success' ? 'Connected' : 'Connection failed — click to retry'}
+      className="flex items-center gap-1.5 group"
+    >
+      <span className={`w-2.5 h-2.5 rounded-full shrink-0 transition-colors ${colors[state]}`} />
+      <span className="text-xs text-gray-400 group-hover:text-gray-600 transition-colors">
+        {state === 'idle' ? 'Test' : state === 'testing' ? 'Testing…' : state === 'success' ? 'Connected' : 'Failed'}
+      </span>
+    </button>
+  );
 }
 
 export default function SettingsModal({ onClose }: Props) {
@@ -11,12 +35,27 @@ export default function SettingsModal({ onClose }: Props) {
   const saved = loadGeminiSettings();
 
   const [apiKey, setApiKey] = useState(saved.apiKey);
+  const [model, setModel] = useState(saved.model);
   const [exampleNumbers, setExampleNumbers] = useState<number[]>(saved.exampleIssueNumbers);
   const [extraInstructions, setExtraInstructions] = useState(saved.extraInstructions);
   const [search, setSearch] = useState('');
+  const [ledState, setLedState] = useState<LedState>('idle');
+
+  async function handleTest() {
+    if (!apiKey.trim()) return;
+    // Save current key+model so testGeminiConnection picks them up
+    saveGeminiSettings({ apiKey, model, exampleIssueNumbers: exampleNumbers, extraInstructions });
+    setLedState('testing');
+    try {
+      await testGeminiConnection();
+      setLedState('success');
+    } catch {
+      setLedState('error');
+    }
+  }
 
   function handleSave() {
-    saveGeminiSettings({ apiKey, exampleIssueNumbers: exampleNumbers, extraInstructions });
+    saveGeminiSettings({ apiKey, model, exampleIssueNumbers: exampleNumbers, extraInstructions });
     onClose();
   }
 
@@ -50,19 +89,32 @@ export default function SettingsModal({ onClose }: Props) {
 
           {/* Gemini API Key */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Gemini API Key
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">Gemini API Key</label>
+              <Led state={ledState} onClick={handleTest} />
+            </div>
             <input
               type="password"
               value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
+              onChange={(e) => { setApiKey(e.target.value); setLedState('idle'); }}
               placeholder="AIza…"
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             <p className="text-xs text-gray-400 mt-1">
               Stored in localStorage only. Used to auto-generate issue descriptions via Gemini.
             </p>
+          </div>
+
+          {/* Model */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Model</label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => { setModel(e.target.value); setLedState('idle'); }}
+              placeholder={DEFAULT_GEMINI_MODEL}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
+            />
           </div>
 
           {/* Example Issues */}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import { useAppStore } from '../store/appStore';
+import { loadGeminiSettings, saveGeminiSettings } from '../lib/gemini';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function SettingsModal({ onClose }: Props) {
+  const { issues } = useAppStore();
+  const saved = loadGeminiSettings();
+
+  const [apiKey, setApiKey] = useState(saved.apiKey);
+  const [exampleNumbers, setExampleNumbers] = useState<number[]>(saved.exampleIssueNumbers);
+  const [extraInstructions, setExtraInstructions] = useState(saved.extraInstructions);
+  const [search, setSearch] = useState('');
+
+  function handleSave() {
+    saveGeminiSettings({ apiKey, exampleIssueNumbers: exampleNumbers, extraInstructions });
+    onClose();
+  }
+
+  function toggleExample(num: number) {
+    setExampleNumbers((prev) => {
+      if (prev.includes(num)) return prev.filter((n) => n !== num);
+      if (prev.length >= 3) return prev;
+      return [...prev, num];
+    });
+  }
+
+  const filtered = issues
+    .filter((i) => i.state === 'open')
+    .filter((i) =>
+      i.title.toLowerCase().includes(search.toLowerCase()) ||
+      String(i.number).includes(search),
+    );
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]">
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-gray-100 shrink-0">
+          <h2 className="font-semibold text-gray-900">Settings</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">×</button>
+        </div>
+
+        <div className="overflow-y-auto flex-1 px-6 py-5 space-y-6">
+
+          {/* Gemini API Key */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Gemini API Key
+            </label>
+            <input
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="AIza…"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              Stored in localStorage only. Used to auto-generate issue descriptions via Gemini.
+            </p>
+          </div>
+
+          {/* Example Issues */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Example Issues{' '}
+              <span className="text-gray-400 font-normal">(up to 3 — sent as style references)</span>
+            </label>
+
+            {exampleNumbers.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {exampleNumbers.map((num) => {
+                  const issue = issues.find((i) => i.number === num);
+                  return (
+                    <span
+                      key={num}
+                      className="flex items-center gap-1 px-2 py-1 bg-blue-50 text-blue-700 text-xs rounded-full border border-blue-200"
+                    >
+                      #{num}{issue ? ` · ${issue.title.slice(0, 28)}…` : ''}
+                      <button
+                        onClick={() => toggleExample(num)}
+                        className="hover:text-red-500 leading-none ml-0.5"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search issues…"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
+            />
+
+            <ul className="border border-gray-200 rounded-lg divide-y divide-gray-100 max-h-44 overflow-y-auto">
+              {filtered.slice(0, 50).map((issue) => {
+                const selected = exampleNumbers.includes(issue.number);
+                const disabled = !selected && exampleNumbers.length >= 3;
+                return (
+                  <li key={issue.number}>
+                    <button
+                      onClick={() => !disabled && toggleExample(issue.number)}
+                      disabled={disabled}
+                      className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 transition-colors ${
+                        selected
+                          ? 'bg-blue-50 text-blue-700'
+                          : disabled
+                          ? 'opacity-40 cursor-not-allowed text-gray-700'
+                          : 'hover:bg-gray-50 text-gray-700'
+                      }`}
+                    >
+                      <span className="text-gray-400 tabular-nums shrink-0 text-xs">#{issue.number}</span>
+                      <span className="truncate">{issue.title}</span>
+                      {selected && <span className="ml-auto text-blue-500 shrink-0 text-xs">✓</span>}
+                    </button>
+                  </li>
+                );
+              })}
+              {filtered.length === 0 && (
+                <li className="px-3 py-3 text-sm text-gray-400">No issues found.</li>
+              )}
+            </ul>
+          </div>
+
+          {/* Additional Instructions */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Additional Instructions
+            </label>
+            <textarea
+              value={extraInstructions}
+              onChange={(e) => setExtraInstructions(e.target.value)}
+              rows={3}
+              placeholder="e.g. Always write in Portuguese. Keep acceptance criteria concise."
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-100 shrink-0 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-900 rounded-lg hover:bg-gray-100 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 text-sm font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-700 transition-colors"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,8 +1,9 @@
-const GEMINI_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent';
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.1-pro-preview';
 
 export interface GeminiSettings {
   apiKey: string;
+  model: string;
   exampleIssueNumbers: number[];
   extraInstructions: string;
 }
@@ -10,6 +11,7 @@ export interface GeminiSettings {
 export function loadGeminiSettings(): GeminiSettings {
   return {
     apiKey: localStorage.getItem('gemini_api_key') ?? '',
+    model: localStorage.getItem('gemini_model') ?? DEFAULT_GEMINI_MODEL,
     exampleIssueNumbers: JSON.parse(localStorage.getItem('gemini_example_issue_numbers') ?? '[]'),
     extraInstructions: localStorage.getItem('gemini_extra_instructions') ?? '',
   };
@@ -17,8 +19,27 @@ export function loadGeminiSettings(): GeminiSettings {
 
 export function saveGeminiSettings(settings: GeminiSettings): void {
   localStorage.setItem('gemini_api_key', settings.apiKey.trim());
+  localStorage.setItem('gemini_model', settings.model.trim() || DEFAULT_GEMINI_MODEL);
   localStorage.setItem('gemini_example_issue_numbers', JSON.stringify(settings.exampleIssueNumbers));
   localStorage.setItem('gemini_extra_instructions', settings.extraInstructions);
+}
+
+function geminiUrl(model: string, apiKey: string): string {
+  return `${GEMINI_BASE}/${model}:generateContent?key=${apiKey}`;
+}
+
+export async function testGeminiConnection(): Promise<void> {
+  const { apiKey, model } = loadGeminiSettings();
+  if (!apiKey) throw new Error('No API key configured.');
+  const res = await fetch(geminiUrl(model, apiKey), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contents: [{ parts: [{ text: 'Say OK' }] }] }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { error?: { message?: string } };
+    throw new Error(err?.error?.message ?? `Gemini API error ${res.status}`);
+  }
 }
 
 export async function generateDescription(
@@ -28,7 +49,7 @@ export async function generateDescription(
   title: string,
   existingBody: string,
 ): Promise<string> {
-  const { apiKey, exampleIssueNumbers, extraInstructions } = loadGeminiSettings();
+  const { apiKey, model, exampleIssueNumbers, extraInstructions } = loadGeminiSettings();
   if (!apiKey) throw new Error('No Gemini API key configured. Add one in Settings.');
 
   // Fetch README
@@ -95,7 +116,7 @@ export async function generateDescription(
     ].join('\n'),
   );
 
-  const res = await fetch(`${GEMINI_URL}?key=${apiKey}`, {
+  const res = await fetch(geminiUrl(model, apiKey), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ contents: [{ parts: [{ text: sections.join('\n\n') }] }] }),

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,5 +1,5 @@
 const GEMINI_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent';
 
 export interface GeminiSettings {
   apiKey: string;

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,0 +1,113 @@
+const GEMINI_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+
+export interface GeminiSettings {
+  apiKey: string;
+  exampleIssueNumbers: number[];
+  extraInstructions: string;
+}
+
+export function loadGeminiSettings(): GeminiSettings {
+  return {
+    apiKey: localStorage.getItem('gemini_api_key') ?? '',
+    exampleIssueNumbers: JSON.parse(localStorage.getItem('gemini_example_issue_numbers') ?? '[]'),
+    extraInstructions: localStorage.getItem('gemini_extra_instructions') ?? '',
+  };
+}
+
+export function saveGeminiSettings(settings: GeminiSettings): void {
+  localStorage.setItem('gemini_api_key', settings.apiKey.trim());
+  localStorage.setItem('gemini_example_issue_numbers', JSON.stringify(settings.exampleIssueNumbers));
+  localStorage.setItem('gemini_extra_instructions', settings.extraInstructions);
+}
+
+export async function generateDescription(
+  token: string,
+  owner: string,
+  repo: string,
+  title: string,
+  existingBody: string,
+): Promise<string> {
+  const { apiKey, exampleIssueNumbers, extraInstructions } = loadGeminiSettings();
+  if (!apiKey) throw new Error('No Gemini API key configured. Add one in Settings.');
+
+  // Fetch README
+  let readme = '';
+  try {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+      headers: { Authorization: `token ${token}`, Accept: 'application/vnd.github.raw+json' },
+    });
+    if (res.ok) readme = await res.text();
+  } catch { /* continue without README */ }
+
+  // Fetch example issue bodies (up to 3)
+  const examples: { title: string; body: string }[] = [];
+  for (const num of exampleIssueNumbers.slice(0, 3)) {
+    try {
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/${num}`, {
+        headers: { Authorization: `token ${token}`, Accept: 'application/vnd.github.v3+json' },
+      });
+      if (res.ok) {
+        const data = await res.json() as { title: string; body: string | null };
+        if (data.body?.trim()) examples.push({ title: data.title, body: data.body });
+      }
+    } catch { /* skip */ }
+  }
+
+  // Build prompt
+  const sections: string[] = [
+    'You are a technical writer helping write GitHub issue descriptions. Use clear, concise Markdown.',
+  ];
+
+  if (readme) {
+    sections.push(`## Project Context (README)\n${readme.slice(0, 3000)}`);
+  }
+
+  if (examples.length > 0) {
+    sections.push('## Style Examples\nHere are well-written issues from this project — match their tone and structure:');
+    examples.forEach((ex, i) => {
+      sections.push(`### Example ${i + 1}: ${ex.title}\n${ex.body}`);
+    });
+  }
+
+  if (extraInstructions.trim()) {
+    sections.push(`## Additional Instructions\n${extraInstructions.trim()}`);
+  }
+
+  sections.push(
+    [
+      '## Task',
+      'Write a description for the issue below using exactly this three-section structure:',
+      '',
+      '### Background',
+      '(current state, pain point, why this change is needed)',
+      '',
+      '### Solution',
+      '(technical approach, key files/components to change)',
+      '',
+      '### Acceptance Criteria',
+      '(bulleted list of specific, verifiable conditions)',
+      '',
+      `Issue title: ${title}`,
+      existingBody ? `\nExisting notes:\n${existingBody}` : '',
+      '',
+      'Return only the Markdown. Do not wrap it in a code block.',
+    ].join('\n'),
+  );
+
+  const res = await fetch(`${GEMINI_URL}?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contents: [{ parts: [{ text: sections.join('\n\n') }] }] }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { error?: { message?: string } };
+    throw new Error(err?.error?.message ?? `Gemini API error ${res.status}`);
+  }
+
+  const data = await res.json() as { candidates?: { content?: { parts?: { text?: string }[] } }[] };
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+  if (!text) throw new Error('Gemini returned an empty response');
+  return text;
+}


### PR DESCRIPTION
## Summary
- Adds a **Settings modal** (accessible from the header) where users configure their Gemini API key, pick up to 3 example issues as style references, and write additional instructions for the model.
- Adds a **✦ Generate with AI** button to both the Create and Edit Issue modals; it calls Gemini 1.5 Flash with the issue title, README, example issues, and extra instructions as context.
- All AI settings are stored in `localStorage` only and never sent anywhere except `generativelanguage.googleapis.com`.

## Implementation notes
- Gemini prompt logic is isolated in `src/lib/gemini.ts` (`generateDescription`, `loadGeminiSettings`, `saveGeminiSettings`).
- The Generate button is only rendered when a Gemini API key is configured — no UI noise for users who don't use AI.
- README is fetched via the GitHub raw API using the existing token; failures are silently skipped so generation still works without a README.
- Example issue bodies are fetched individually; unavailable issues are skipped.

## Test plan
- [ ] Open Settings from the header — verify all three fields render and save to localStorage.
- [ ] Add a Gemini API key — verify the **✦ Generate with AI** button appears in Edit Issue and New Issue modals.
- [ ] Click Generate with a title set — verify the body textarea is populated with a Background / Solution / Acceptance Criteria structure.
- [ ] Select 1–3 example issues in Settings — verify a 4th cannot be selected.
- [ ] Add additional instructions (e.g. "write in Portuguese") — verify generated output reflects them.
- [ ] Clear the API key — verify the Generate button disappears.
- [ ] Simulate a bad API key — verify an inline error message is shown.

Closes #33