### PR TITLE
feat: resizable columns for Grid and Kanban views (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A "No Status" column and "No Wave" swimlane catch any untagged issues.
 All structure comes from GitHub labels with these prefixes:
 
 | Prefix | Example | Purpose |
-|--------|---------|---------|
+|--------|---------|---------| 
 | `e_` | `e_Auth` | Epic — defines Grid columns |
 | `w_` | `w_Q1` | Wave / release — defines Grid rows and Kanban swimlanes |
 | `s_` | `s_Done` | Status — defines Kanban columns |
@@ -46,6 +46,18 @@ Labels are created automatically on GitHub when you add them through the **Epics
 - Manage epic, wave, and status labels without leaving the app
 - Layout persisted to Firestore (optional — works fully offline)
 - Real-time sync with GitHub Issues API
+- **Resizable columns** in both Grid and Kanban views (see below)
+
+## Resizable Columns
+
+Both the **Grid** (Epic) and **Kanban** (Status) views support drag-to-resize columns:
+
+- **Hover** over the right edge of any column header to reveal a resize cursor and a subtle visual handle.
+- **Drag** the handle left or right to adjust the column width in real time.
+- Width is constrained between **150 px** (minimum) and **600 px** (maximum) to prevent layout breakage.
+- Custom widths are **persisted to `localStorage`** (key: `gh_column_widths`) so your preferred layout is restored on page refresh or the next session.
+- Column widths are stored by column identifier (project node ID for Epic columns, status label string for Kanban columns), so renaming a wave or status does not reset unrelated column widths.
+- The resize handle stops event propagation, so dragging the handle will never accidentally trigger the existing column **reorder** drag-and-drop.
 
 ## Getting started
 

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -4,6 +4,12 @@ import { useAppStore } from '../store/appStore';
 import type { GitHubIssue, GitHubMilestone } from '../types';
 import IssueCard from './IssueCard';
 import CreateIssueModal from './CreateIssueModal';
+import { ResizeHandle } from './ResizeHandle';
+
+/** Default column width (px) for Kanban / Status columns (matches previous Tailwind w-72 = 288px). */
+const KANBAN_COL_WIDTH = 288;
+/** Sentinel key for the "No Status" catch-all column. */
+const NO_STATUS_KEY = '__no_status__';
 
 function getStatusLabel(issue: GitHubIssue): string | null {
   const label = issue.labels.find((l) => l.name.startsWith('s_'));
@@ -43,7 +49,7 @@ function sortedMilestones(milestones: GitHubMilestone[], milestoneOrder: number[
 }
 
 export default function KanbanView() {
-  const { issues, milestones, statusLabels, layout, showClosedIssues, moveIssueInKanban } = useAppStore();
+  const { issues, milestones, statusLabels, layout, showClosedIssues, moveIssueInKanban, columnWidths } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
 
@@ -53,6 +59,9 @@ export default function KanbanView() {
   const cols = [...statusLabels, ''];
 
   const visibleIssues = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
+
+  /** Returns the stored width (px) for a status column, falling back to the default. */
+  const statusColWidth = (status: string) => columnWidths[status || NO_STATUS_KEY] ?? KANBAN_COL_WIDTH;
 
   function cellIssues(milestoneNumber: number | null, status: string): GitHubIssue[] {
     return visibleIssues.filter((issue) => {
@@ -87,14 +96,22 @@ export default function KanbanView() {
           <table className="border-collapse">
             <thead>
               <tr>
-                {cols.map((status) => (
-                  <th
-                    key={status || 'no-status'}
-                    className="sticky top-0 z-20 bg-green-50 border border-gray-200 px-4 py-3 text-sm font-semibold text-green-900 text-center w-72 min-w-72 whitespace-nowrap"
-                  >
-                    {status || <span className="text-green-400 font-normal italic">No Status</span>}
-                  </th>
-                ))}
+                {cols.map((status) => {
+                  const colW = statusColWidth(status);
+                  return (
+                    <th
+                      key={status || 'no-status'}
+                      style={{ width: colW, minWidth: colW, maxWidth: colW }}
+                      className="sticky top-0 z-20 bg-green-50 border border-gray-200 px-4 py-3 text-sm font-semibold text-green-900 text-center whitespace-nowrap"
+                    >
+                      {status || <span className="text-green-400 font-normal italic">No Status</span>}
+                      <ResizeHandle
+                        columnKey={status || NO_STATUS_KEY}
+                        defaultWidth={KANBAN_COL_WIDTH}
+                      />
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody>
@@ -115,10 +132,12 @@ export default function KanbanView() {
                     {cols.map((status) => {
                       const milestoneNumber = milestone?.number ?? null;
                       const items = cellIssues(milestoneNumber, status);
+                      const colW = statusColWidth(status);
                       return (
                         <td
                           key={status || 'no-status'}
-                          className="border border-gray-200 align-top p-2 bg-white w-72 min-w-72"
+                          style={{ width: colW, minWidth: colW, maxWidth: colW }}
+                          className="border border-gray-200 align-top p-2 bg-white"
                         >
                           <Droppable droppableId={kanbanCellId(status, milestoneNumber)} type="CARD">
                             {(provided, snapshot) => (

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -1,0 +1,74 @@
+import { useRef, useCallback } from 'react';
+import { useAppStore } from '../store/appStore';
+
+export const MIN_COL_WIDTH = 150;
+export const MAX_COL_WIDTH = 600;
+
+interface ResizeHandleProps {
+  /** Unique key used to look up / store width in Zustand + localStorage */
+  columnKey: string;
+  /** Fallback width (px) when no custom width has been saved yet */
+  defaultWidth: number;
+}
+
+/**
+ * Draggable resize handle that sits on the right edge of a column header.
+ *
+ * The parent <th> must already be a positioned element (sticky / relative / fixed)
+ * so that the absolute child is correctly contained.
+ *
+ * Usage:
+ *   <th style={{ width: colW, minWidth: colW }} className="... sticky top-0">
+ *     Column label
+ *     <ResizeHandle columnKey="my-col" defaultWidth={200} />
+ *   </th>
+ */
+export function ResizeHandle({ columnKey, defaultWidth }: ResizeHandleProps) {
+  const columnWidths = useAppStore((s) => s.columnWidths);
+  const setColumnWidth = useAppStore((s) => s.setColumnWidth);
+
+  // Keep start values in refs so the closure inside addEventListener is always fresh
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Prevent the mousedown from bubbling to the drag-handle on the parent <th>
+      e.preventDefault();
+      e.stopPropagation();
+
+      startXRef.current = e.clientX;
+      startWidthRef.current = columnWidths[columnKey] ?? defaultWidth;
+
+      const onMouseMove = (ev: MouseEvent) => {
+        const delta = ev.clientX - startXRef.current;
+        const next = Math.min(
+          MAX_COL_WIDTH,
+          Math.max(MIN_COL_WIDTH, startWidthRef.current + delta),
+        );
+        setColumnWidth(columnKey, next);
+      };
+
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    // columnWidths is needed so startWidthRef captures the latest stored value
+    [columnKey, defaultWidth, columnWidths, setColumnWidth],
+  );
+
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      className="absolute right-0 top-0 h-full w-2 cursor-col-resize flex items-center justify-center group/resize select-none z-10"
+      title="Drag to resize column"
+    >
+      {/* Subtle visual indicator — becomes visible on hover */}
+      <div className="w-0.5 h-3/4 rounded transition-all bg-current opacity-0 group-hover/resize:opacity-25" />
+    </div>
+  );
+}

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -4,6 +4,12 @@ import { useAppStore } from '../store/appStore';
 import type { GitHubIssue, GitHubMilestone, GitHubProject } from '../types';
 import IssueCard from './IssueCard';
 import CreateIssueModal from './CreateIssueModal';
+import { ResizeHandle } from './ResizeHandle';
+
+/** Default column width (px) for Grid / Epic columns. */
+const GRID_COL_WIDTH = 200;
+/** Sentinel key used to store the width of the "No Epic" catch-all column. */
+const NO_EPIC_KEY = '__no_epic__';
 
 function sortedProjects(projects: GitHubProject[], epicOrder: number[]): GitHubProject[] {
   const open = projects.filter((p) => !p.closed);
@@ -103,7 +109,7 @@ export default function StoryMap() {
   const {
     issues, projects, projectIssues, milestones, layout,
     reorderProjects, reorderMilestones, moveIssueInGrid, showClosedIssues,
-    createProject, createMilestone,
+    createProject, createMilestone, columnWidths,
   } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
@@ -115,6 +121,11 @@ export default function StoryMap() {
   const [addingWave, setAddingWave] = useState(false);
   const [newWaveTitle, setNewWaveTitle] = useState('');
   const [waveSaving, setWaveSaving] = useState(false);
+
+  /** Returns the stored width (px) for an epic column, falling back to the default. */
+  const epicColWidth = (projectId: string) => columnWidths[projectId] ?? GRID_COL_WIDTH;
+  /** Width for the "No Epic" catch-all column. */
+  const noEpicColWidth = columnWidths[NO_EPIC_KEY] ?? GRID_COL_WIDTH;
 
   function showError(msg: string) {
     setMoveError(msg);
@@ -254,26 +265,46 @@ export default function StoryMap() {
               <Droppable droppableId="columns" direction="horizontal" type="COLUMN">
                 {(provided) => (
                   <tr ref={provided.innerRef} {...provided.droppableProps}>
+                    {/* Row-label stub — fixed width, not a resizable data column */}
                     <th className="sticky left-0 top-0 z-30 bg-white border border-gray-200 w-[200px] min-w-[200px] max-w-[200px]" />
-                    {cols.map((project, index) => (
-                      <Draggable key={project.id} draggableId={project.id} index={index}>
-                        {(provided, snapshot) => (
-                          <th
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            {...provided.dragHandleProps}
-                            className={`sticky top-0 z-20 border border-gray-200 px-4 py-3 text-sm font-semibold text-blue-900 text-center w-[200px] min-w-[200px] max-w-[200px] whitespace-nowrap cursor-grab select-none transition-colors ${
-                              snapshot.isDragging ? 'bg-blue-100 shadow-lg z-50' : 'bg-blue-50'
-                            }`}
-                          >
-                            <span className="text-blue-300 mr-1.5 text-xs">⠿</span>
-                            {project.title}
-                          </th>
-                        )}
-                      </Draggable>
-                    ))}
+
+                    {cols.map((project, index) => {
+                      const colW = epicColWidth(project.id);
+                      return (
+                        <Draggable key={project.id} draggableId={project.id} index={index}>
+                          {(provided, snapshot) => (
+                            <th
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              {...provided.dragHandleProps}
+                              style={{
+                                // Preserve dnd transform/transition, then apply dynamic width
+                                ...provided.draggableProps.style,
+                                width: colW,
+                                minWidth: colW,
+                                maxWidth: colW,
+                              }}
+                              className={`sticky top-0 z-20 border border-gray-200 px-4 py-3 text-sm font-semibold text-blue-900 text-center whitespace-nowrap cursor-grab select-none transition-colors ${
+                                snapshot.isDragging ? 'bg-blue-100 shadow-lg z-50' : 'bg-blue-50'
+                              }`}
+                            >
+                              <span className="text-blue-300 mr-1.5 text-xs">⠿</span>
+                              {project.title}
+                              {/* stopPropagation inside ResizeHandle prevents dragging from firing */}
+                              <ResizeHandle columnKey={project.id} defaultWidth={GRID_COL_WIDTH} />
+                            </th>
+                          )}
+                        </Draggable>
+                      );
+                    })}
+
                     {provided.placeholder}
-                    <th className="sticky top-0 z-20 bg-gray-50 border border-gray-200 px-2 py-2 text-sm font-semibold text-gray-500 text-center w-[200px] min-w-[200px] max-w-[200px]">
+
+                    {/* "No Epic" catch-all column — resizable but not draggable */}
+                    <th
+                      style={{ width: noEpicColWidth, minWidth: noEpicColWidth, maxWidth: noEpicColWidth }}
+                      className="sticky top-0 z-20 bg-gray-50 border border-gray-200 px-2 py-2 text-sm font-semibold text-gray-500 text-center"
+                    >
                       {addingEpic ? (
                         <form onSubmit={handleCreateEpic} className="flex items-center gap-1">
                           <input
@@ -297,6 +328,7 @@ export default function StoryMap() {
                           </button>
                         </div>
                       )}
+                      <ResizeHandle columnKey={NO_EPIC_KEY} defaultWidth={GRID_COL_WIDTH} />
                     </th>
                   </tr>
                 )}
@@ -315,6 +347,7 @@ export default function StoryMap() {
                           {...provided.draggableProps}
                           style={provided.draggableProps.style}
                         >
+                          {/* Row label — fixed width, drag handle for the row */}
                           <th
                             {...provided.dragHandleProps}
                             className={`sticky left-0 z-10 border border-gray-200 px-3 py-2 text-xs font-semibold text-purple-900 text-right align-top pt-3 cursor-grab select-none transition-colors w-[200px] min-w-[200px] max-w-[200px] ${
@@ -324,17 +357,30 @@ export default function StoryMap() {
                             <span className="text-purple-300 mr-1 text-xs">⠿</span>
                             <span className="truncate block">{milestone.title}</span>
                           </th>
-                          {cols.map((project) => (
-                            <td key={project.id} className="border border-gray-200 align-top p-2 bg-white w-[200px] min-w-[200px] max-w-[200px]">
-                              <CardCell
-                                droppableId={cellId(project.id, milestone.number)}
-                                items={cellIssues(project.id, milestone.number)}
-                                onAdd={() => setCreateCell({ projectId: project.id, milestoneNumber: milestone.number })}
-                              />
-                            </td>
-                          ))}
+
+                          {/* Epic data cells — width mirrors the header */}
+                          {cols.map((project) => {
+                            const colW = epicColWidth(project.id);
+                            return (
+                              <td
+                                key={project.id}
+                                style={{ width: colW, minWidth: colW, maxWidth: colW }}
+                                className="border border-gray-200 align-top p-2 bg-white"
+                              >
+                                <CardCell
+                                  droppableId={cellId(project.id, milestone.number)}
+                                  items={cellIssues(project.id, milestone.number)}
+                                  onAdd={() => setCreateCell({ projectId: project.id, milestoneNumber: milestone.number })}
+                                />
+                              </td>
+                            );
+                          })}
+
                           {/* No Epic cell */}
-                          <td className="border border-gray-200 align-top p-2 bg-gray-50/50 w-[200px] min-w-[200px] max-w-[200px]">
+                          <td
+                            style={{ width: noEpicColWidth, minWidth: noEpicColWidth, maxWidth: noEpicColWidth }}
+                            className="border border-gray-200 align-top p-2 bg-gray-50/50"
+                          >
                             <CardCell
                               droppableId={cellId('', milestone.number)}
                               items={noProjectCellIssues(milestone.number)}
@@ -375,17 +421,30 @@ export default function StoryMap() {
                         </div>
                       )}
                     </th>
-                    {cols.map((project) => (
-                      <td key={project.id} className="border border-gray-200 align-top p-2 bg-white w-[200px] min-w-[200px] max-w-[200px]">
-                        <CardCell
-                          droppableId={cellId(project.id, null)}
-                          items={cellIssues(project.id, null)}
-                          onAdd={() => setCreateCell({ projectId: project.id, milestoneNumber: null })}
-                        />
-                      </td>
-                    ))}
+
+                    {/* Epic data cells for No Wave row */}
+                    {cols.map((project) => {
+                      const colW = epicColWidth(project.id);
+                      return (
+                        <td
+                          key={project.id}
+                          style={{ width: colW, minWidth: colW, maxWidth: colW }}
+                          className="border border-gray-200 align-top p-2 bg-white"
+                        >
+                          <CardCell
+                            droppableId={cellId(project.id, null)}
+                            items={cellIssues(project.id, null)}
+                            onAdd={() => setCreateCell({ projectId: project.id, milestoneNumber: null })}
+                          />
+                        </td>
+                      );
+                    })}
+
                     {/* No Epic / No Wave corner */}
-                    <td className="border border-gray-200 align-top p-2 bg-gray-50/50 w-[200px] min-w-[200px] max-w-[200px]">
+                    <td
+                      style={{ width: noEpicColWidth, minWidth: noEpicColWidth, maxWidth: noEpicColWidth }}
+                      className="border border-gray-200 align-top p-2 bg-gray-50/50"
+                    >
                       <CardCell
                         droppableId={cellId('', null)}
                         items={noProjectCellIssues(null)}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -17,6 +17,8 @@ interface AppState {
   showClosedIssues: boolean;
   projects: GitHubProject[];
   projectIssues: Record<string, number[]>; // project node_id → issue numbers
+  /** Column widths in pixels, keyed by column ID (project node_id or status label). */
+  columnWidths: Record<string, number>;
 
   setCredentials: (token: string, owner: string, repo: string) => void;
   fetchIssues: () => Promise<void>;
@@ -67,6 +69,8 @@ interface AppState {
     fromMilestoneNumber: number | null,
     toMilestoneNumber: number | null,
   ) => Promise<void>;
+  /** Persist a custom pixel width for the given column key to the store and localStorage. */
+  setColumnWidth: (key: string, width: number) => void;
 }
 
 const emptyLayout: StoryMapLayout = { epicOrder: [], milestoneOrder: [], storyOrder: { backlog: [] } };
@@ -118,6 +122,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   showClosedIssues: false,
   projects: [],
   projectIssues: {},
+  columnWidths: JSON.parse(localStorage.getItem('gh_column_widths') ?? '{}') as Record<string, number>,
 
   setCredentials: (token, owner, repo) => {
     localStorage.setItem('gh_token', token);
@@ -650,6 +655,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newLayout = { ...layout, milestoneOrder };
     set({ layout: newLayout });
     saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
+  },
+
+  setColumnWidth: (key, width) => {
+    const updated = { ...get().columnWidths, [key]: width };
+    localStorage.setItem('gh_column_widths', JSON.stringify(updated));
+    set({ columnWidths: updated });
   },
 
   moveIssueInGrid: async (issueNumber, fromProjectId, toProjectId, fromMilestoneNumber, toMilestoneNumber) => {


### PR DESCRIPTION
## Summary

Implements draggable resize handles on column headers for both the **Grid** (Epic columns) and **Kanban** (Status columns) views, as requested in #32.

---

## Changes

### `src/components/ResizeHandle.tsx` *(new)*
A self-contained `ResizeHandle` component that:
- Renders an absolutely-positioned drag target on the right edge of any column header (the parent `<th>` is already `position: sticky`, which serves as the containing block).
- On `mousedown`, attaches `mousemove` / `mouseup` listeners to `document` so resizing works even when the pointer leaves the header.
- Calls `e.stopPropagation()` to prevent the resize gesture from triggering the existing DnD column-reorder drag.
- Enforces a minimum width of **150 px** and a maximum of **600 px**.
- Shows a subtle visual bar on hover (`cursor-col-resize`) for discoverability.

### `src/store/appStore.ts`
- Added `columnWidths: Record<string, number>` to the Zustand state — initialized from `localStorage` key `gh_column_widths` on startup.
- Added `setColumnWidth(key, width)` action — updates the store and immediately writes the new widths map back to `localStorage` so the layout persists across sessions.

### `src/components/StoryMap.tsx` *(Grid view)*
- Imported `ResizeHandle`.
- Added `columnWidths` from the store and two helpers: `epicColWidth(projectId)` and `noEpicColWidth`.
- Epic column `<th>` elements (inside `<Draggable>`) now use `style={{ width, minWidth, maxWidth }}` derived from the store; dnd transform styles are preserved by spreading `provided.draggableProps.style` first.
- Each epic `<th>` carries a `<ResizeHandle>` keyed by the GitHub Project **node ID** (stable even if the project is renamed).
- The "No Epic" catch-all column is also resizable, keyed by the sentinel `__no_epic__`.
- All data `<td>` elements in every row mirror the matching header width via inline style (Tailwind fixed-width classes removed from those elements).

### `src/components/KanbanView.tsx` *(Kanban view)*
- Imported `ResizeHandle`.
- Added `columnWidths` from the store and `statusColWidth(status)` helper (default 288 px, matching the previous `w-72` Tailwind class).
- Status `<th>` elements now use dynamic inline widths and carry a `<ResizeHandle>` keyed by the status label string (or `__no_status__` for the fallback column).
- Corresponding `<td>` cells updated to use the same dynamic width.

### `README.md`
- Added a **Resizable Columns** section documenting the feature, constraints, persistence mechanism, and interaction with the existing column reorder.

---

## Acceptance criteria

| Scenario | Status |
|---|---|
| Hover → resize cursor + visual handle appear | ✅ `cursor-col-resize` + hover opacity on the handle bar |
| Drag → column width updates in real time | ✅ `mousemove` listener updates Zustand state on every frame |
| Width constraints enforced | ✅ clamped to [150 px, 600 px] |
| Layout persists across refresh | ✅ saved to `localStorage` via `setColumnWidth` |

Closes #32