### PR TITLE
feat: clicking an issue opens a read-only view with Markdown rendering (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A "No Status" column and "No Wave" swimlane catch any untagged issues.
 All structure comes from GitHub labels with these prefixes:
 
 | Prefix | Example | Purpose |
-|--------|---------|---------|
+|--------|---------|---------| 
 | `e_` | `e_Auth` | Epic — defines Grid columns |
 | `w_` | `w_Q1` | Wave / release — defines Grid rows and Kanban swimlanes |
 | `s_` | `s_Done` | Status — defines Kanban columns |
@@ -42,13 +42,34 @@ Labels are created automatically on GitHub when you add them through the **Epics
 - Kanban view: status columns with wave swimlanes
 - Grid/Kanban toggle in the toolbar
 - Create issues with pre-filled epic, wave, and status from any cell
+- **Read-only issue view** — clicking an issue card opens a formatted read-only modal (see below)
 - Edit, close, and permanently delete issues inline
 - Manage epic, wave, and status labels without leaving the app
 - Layout persisted to Firestore (optional — works fully offline)
 - Real-time sync with GitHub Issues API
 - Resizable columns in both Grid and Kanban views (see below)
-- Describe with AI uses the epic, the wave, the issue tilte, example issues, the code and additional instructions to create the issue's spec
+- Describe with AI uses the epic, the wave, the issue title, example issues, the code and additional instructions to create the issue's spec
 - Code with AI delegate issue implementation to a Claude Managed Agent (creates branch, writes code, opens PR)
+
+## Read-only issue view
+
+Clicking any issue card in the Grid or Kanban view opens a **read-only modal** that presents the issue in a clean, safe reading environment:
+
+- **Formatted Markdown** — the description is fully rendered with support for headings, bold/italic/strikethrough, fenced code blocks (with syntax highlighting theme), inline code, unordered and ordered lists, task lists (`- [ ]` / `- [x]`), blockquotes, thematic breaks, and Markdown links.
+- **Metadata chips** — wave (milestone), epic (project), status label, and assignee avatars are shown at a glance below the title.
+- **Action toolbar** (top-right corner) — contains the same actions available on issue cards:
+  | Button | Action |
+  |--------|--------|
+  | ✏️ Edit | Opens the edit modal (description tab) |
+  | ✓ Close | Closes the issue on GitHub |
+  | 🗑 Delete | Permanently deletes the issue |
+  | ✦ Describe with AI | Opens the edit modal to generate a description via Gemini (visible when Gemini is configured) |
+  | ⚡ Code with AI | Opens the edit modal on the Implementation tab to start an AI coding session (visible when Anthropic is configured) |
+- **Deep-link support** — the URL updates to `/issue/{number}` when the modal is open; reloading the page reopens the same modal.
+
+### Quick-edit fast path
+
+The hover overlay on each card still exposes **Edit**, **Close**, and **Delete** buttons directly, letting power users skip the read view and jump straight to the edit form.
 
 ## Getting started
 
@@ -111,6 +132,7 @@ All values are stored in `localStorage` only.
 - **Persistence:** Firebase Firestore (optional)
 - **AI — description generation:** Google Gemini API (direct `fetch`)
 - **AI — code implementation:** Anthropic Claude Managed Agents API (direct `fetch`, beta `managed-agents-2026-04-01`)
+- **Markdown rendering:** Built-in lightweight renderer (`src/lib/markdown.ts`) — no extra dependency
 - **Build:** Vite
 
 ## Troubleshooting

--- a/src/components/EditIssueModal.tsx
+++ b/src/components/EditIssueModal.tsx
@@ -20,6 +20,8 @@ import type { AiLinks, AgentEvent } from '../lib/anthropic';
 interface Props {
   issue: GitHubIssue;
   onClose: () => void;
+  /** Which tab to show on first render. Defaults to 'description'. */
+  initialTab?: 'description' | 'ai';
 }
 
 interface LogEntry {
@@ -172,7 +174,7 @@ function AiImplementationPanel({
   );
 }
 
-export default function EditIssueModal({ issue, onClose }: Props) {
+export default function EditIssueModal({ issue, onClose, initialTab = 'description' }: Props) {
   const { token, owner, repo, projects, projectIssues, milestones, updateIssue, addIssueToProject, removeIssueFromProject } = useAppStore();
 
   const [title, setTitle] = useState(issue.title);
@@ -422,7 +424,8 @@ export default function EditIssueModal({ issue, onClose }: Props) {
     }
   }
 
-  const [descTab, setDescTab] = useState<'description' | 'ai'>('description');
+  // initialTab controls which tab is active on first render.
+  const [descTab, setDescTab] = useState<'description' | 'ai'>(initialTab);
 
   return (
     <div

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react';
 import type { GitHubIssue } from '../types';
 import { useAppStore } from '../store/appStore';
 import EditIssueModal from './EditIssueModal';
+import IssueReadModal from './IssueReadModal';
 
 function truncateMiddle(text: string, max: number): string {
   if (text.length <= max) return text;
@@ -17,9 +18,17 @@ interface Props {
 
 export default function IssueCard({ issue }: Props) {
   const { closeIssue, deleteIssue } = useAppStore();
-  const [showEdit, setShowEdit] = useState(
-    () => window.location.pathname === `/issue/${issue.number}`
+
+  // Read-only view — opens when the card body is clicked or when the URL
+  // already points to this issue (deep-link / page-refresh support).
+  const [showReadModal, setShowReadModal] = useState(
+    () => window.location.pathname === `/issue/${issue.number}`,
   );
+
+  // Direct-edit path — opened via the hover-action Edit button (fast path)
+  // so power-users can skip the read modal entirely.
+  const [showEdit, setShowEdit] = useState(false);
+
   const [busy, setBusy] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [showBadgeTip, setShowBadgeTip] = useState(false);
@@ -27,13 +36,14 @@ export default function IssueCard({ issue }: Props) {
   const cardRef = useRef<HTMLDivElement>(null);
   const calloutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Keep the browser URL in sync with the read modal.
   useEffect(() => {
-    if (showEdit) {
+    if (showReadModal) {
       history.pushState({}, '', `/issue/${issue.number}`);
     } else if (window.location.pathname === `/issue/${issue.number}`) {
       history.pushState({}, '', '/');
     }
-  }, [showEdit, issue.number]);
+  }, [showReadModal, issue.number]);
 
   const statusLabel = issue.labels.find(l => l.name.startsWith('s_'));
   const statusName = statusLabel ? statusLabel.name.slice(2) : null;
@@ -86,6 +96,7 @@ export default function IssueCard({ issue }: Props) {
         ref={cardRef}
         onMouseEnter={onCardEnter}
         onMouseLeave={onCardLeave}
+        onClick={() => setShowReadModal(true)}
         className={`relative select-none cursor-pointer text-sm ${hovered ? 'z-20' : ''} ${
           busy ? 'opacity-40 pointer-events-none' :
           issue.state === 'closed' ? 'opacity-60' : ''
@@ -148,6 +159,7 @@ export default function IssueCard({ issue }: Props) {
 
           {/* Action buttons — absolute overlay on the right, visible on hover */}
           <div className={`absolute right-1.5 inset-y-0 flex items-center gap-1 transition-opacity ${hovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+            {/* Edit — fast path: bypasses the read modal and opens the edit form directly */}
             <button
               onClick={e => { e.stopPropagation(); setShowEdit(true); }}
               title="Edit issue"
@@ -198,7 +210,15 @@ export default function IssueCard({ issue }: Props) {
         document.body
       )}
 
-      {showEdit && <EditIssueModal issue={issue} onClose={() => setShowEdit(false)} />}
+      {/* Read-only view — opened by clicking the card body */}
+      {showReadModal && (
+        <IssueReadModal issue={issue} onClose={() => setShowReadModal(false)} />
+      )}
+
+      {/* Direct-edit fast path — opened via the hover Edit button */}
+      {showEdit && (
+        <EditIssueModal issue={issue} onClose={() => setShowEdit(false)} />
+      )}
     </>
   );
 }

--- a/src/components/IssueReadModal.tsx
+++ b/src/components/IssueReadModal.tsx
@@ -1,0 +1,269 @@
+import { useState } from 'react';
+import type { GitHubIssue } from '../types';
+import { useAppStore } from '../store/appStore';
+import EditIssueModal from './EditIssueModal';
+import { parseMarkdownToHTML } from '../lib/markdown';
+import { loadGeminiSettings } from '../lib/gemini';
+import { loadAnthropicSettings } from '../lib/anthropic';
+
+interface Props {
+  issue: GitHubIssue;
+  onClose: () => void;
+}
+
+/**
+ * Read-only view of a GitHub issue.
+ * Renders the description as formatted Markdown and exposes an action
+ * toolbar (Edit, Close, Delete, Describe with AI, Code with AI) in the
+ * top-right corner.
+ */
+export default function IssueReadModal({ issue, onClose }: Props) {
+  const { closeIssue, deleteIssue, projects, projectIssues } = useAppStore();
+
+  const [showEdit, setShowEdit] = useState(false);
+  const [editInitialTab, setEditInitialTab] = useState<'description' | 'ai'>('description');
+  const [busy, setBusy] = useState(false);
+
+  const hasGeminiKey = Boolean(loadGeminiSettings().apiKey);
+  const anthropicSettings = loadAnthropicSettings();
+  const hasAnthropicSettings = Boolean(
+    anthropicSettings.apiKey &&
+    anthropicSettings.agentId &&
+    anthropicSettings.envId &&
+    anthropicSettings.vaultId,
+  );
+
+  // Find the epic (project) this issue belongs to
+  const epic = projects.find((p) => (projectIssues[p.id] ?? []).includes(issue.number));
+
+  // Strip the AI section from the body before rendering
+  const displayBody = (() => {
+    const b = issue.body ?? '';
+    const sentinelIdx = b.indexOf('\n\n<!-- ai-section -->');
+    if (sentinelIdx >= 0) return b.slice(0, sentinelIdx);
+    const legacyIdx = b.indexOf('\n\n<!-- ai-links\n');
+    return legacyIdx >= 0 ? b.slice(0, legacyIdx) : b;
+  })();
+
+  const renderedBody = displayBody.trim() ? parseMarkdownToHTML(displayBody) : null;
+
+  const statusLabel = issue.labels.find((l) => l.name.startsWith('s_'));
+
+  async function handleClose(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!confirm(`Close issue #${issue.number}?`)) return;
+    setBusy(true);
+    try {
+      await closeIssue(issue.number);
+      onClose();
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!confirm(`Permanently delete issue #${issue.number}? This cannot be undone.`)) return;
+    setBusy(true);
+    try {
+      await deleteIssue(issue.number, issue.node_id);
+      onClose();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to delete');
+      setBusy(false);
+    }
+  }
+
+  function openEdit(tab: 'description' | 'ai' = 'description') {
+    setEditInitialTab(tab);
+    setShowEdit(true);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className={`bg-white rounded-2xl shadow-xl w-full max-w-2xl flex flex-col h-[90vh] ${
+          busy ? 'opacity-60 pointer-events-none' : ''
+        }`}
+      >
+        {/* ── Header ─────────────────────────────────────────────────── */}
+        <div className="flex items-start justify-between px-6 pt-5 pb-4 border-b border-gray-100 gap-4 shrink-0">
+          {/* Left: status, number, title, metadata */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              {/* Open / Closed badge */}
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${
+                  issue.state === 'open'
+                    ? 'bg-blue-50 text-blue-700 border-blue-200'
+                    : 'bg-green-50 text-green-700 border-green-200'
+                }`}
+              >
+                {issue.state === 'open' ? (
+                  <svg className="w-2 h-2" fill="currentColor" viewBox="0 0 8 8">
+                    <circle cx="4" cy="4" r="4" />
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                )}
+                {issue.state === 'open' ? 'Open' : 'Closed'}
+              </span>
+
+              {/* Issue number → GitHub link */}
+              <a
+                href={issue.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-gray-400 hover:text-blue-500 transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                #{issue.number} ↗
+              </a>
+            </div>
+
+            {/* Title */}
+            <h2 className="text-lg font-semibold text-gray-900 mt-1.5 leading-snug break-words">
+              {issue.title}
+            </h2>
+
+            {/* Meta chips */}
+            <div className="flex flex-wrap items-center gap-2 mt-2">
+              {issue.milestone && (
+                <span className="text-xs text-purple-700 bg-purple-50 px-2 py-0.5 rounded-full border border-purple-200">
+                  🌊 {issue.milestone.title}
+                </span>
+              )}
+              {epic && (
+                <span className="text-xs text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full border border-blue-200">
+                  ⬡ {epic.title}
+                </span>
+              )}
+              {statusLabel && (
+                <span className="text-xs text-green-700 bg-green-50 px-2 py-0.5 rounded-full border border-green-200">
+                  ◆ {statusLabel.name.slice(2)}
+                </span>
+              )}
+              {issue.assignees.length > 0 && (
+                <div className="flex items-center gap-1.5">
+                  <div className="flex -space-x-1">
+                    {issue.assignees.map((user) => (
+                      <img
+                        key={user.login}
+                        src={user.avatar_url}
+                        alt={user.login}
+                        title={user.login}
+                        className="w-5 h-5 rounded-full ring-1 ring-white"
+                      />
+                    ))}
+                  </div>
+                  <span className="text-xs text-gray-500">
+                    {issue.assignees.map((u) => u.login).join(', ')}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right: action toolbar */}
+          <div className="flex items-center gap-1 shrink-0 pt-0.5">
+            {/* Edit */}
+            <button
+              onClick={() => openEdit('description')}
+              title="Edit issue"
+              className="p-1.5 text-blue-500 rounded-lg border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+              </svg>
+            </button>
+
+            {/* Close issue (only when open) */}
+            {issue.state === 'open' && (
+              <button
+                onClick={handleClose}
+                title="Close issue"
+                className="p-1.5 text-green-600 rounded-lg border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </button>
+            )}
+
+            {/* Delete */}
+            <button
+              onClick={handleDelete}
+              title="Delete issue permanently"
+              className="p-1.5 text-red-500 rounded-lg border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+            </button>
+
+            {/* Describe with AI (requires Gemini key) */}
+            {hasGeminiKey && (
+              <button
+                onClick={() => openEdit('description')}
+                title="Describe with AI"
+                className="p-1.5 text-purple-600 rounded-lg border border-purple-200 bg-purple-50 hover:bg-purple-100 transition-colors text-sm font-bold leading-none"
+              >
+                ✦
+              </button>
+            )}
+
+            {/* Code with AI (requires Anthropic settings) */}
+            {hasAnthropicSettings && (
+              <button
+                onClick={() => openEdit('ai')}
+                title="Code with AI"
+                className="p-1.5 text-orange-600 rounded-lg border border-orange-200 bg-orange-50 hover:bg-orange-100 transition-colors text-sm leading-none"
+              >
+                ⚡
+              </button>
+            )}
+
+            {/* Dismiss modal */}
+            <button
+              onClick={onClose}
+              title="Close"
+              className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors ml-0.5"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* ── Body ───────────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {renderedBody ? (
+            <div
+              className="issue-body"
+              // Content originates from GitHub Issues written by repo contributors.
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: renderedBody }}
+            />
+          ) : (
+            <p className="text-sm text-gray-400 italic">No description provided.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Edit modal stacked on top when needed */}
+      {showEdit && (
+        <EditIssueModal
+          issue={issue}
+          initialTab={editInitialTab}
+          onClose={() => setShowEdit(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,172 @@
+/**
+ * Very small Markdown → HTML converter for GitHub issue bodies.
+ * Supports: headings, fenced code blocks, inline code, bold/italic/strikethrough,
+ * task lists, unordered & ordered lists, blockquotes, thematic breaks, and links.
+ */
+
+function escapeHTML(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function inlineElements(text: string): string {
+  let r = escapeHTML(text);
+
+  // Inline code – must run before bold/italic to avoid double-processing
+  r = r.replace(/`([^`\n]+)`/g, '<code class="bg-gray-100 px-1 py-0.5 rounded text-xs font-mono text-gray-800">$1</code>');
+
+  // Bold + italic combined
+  r = r.replace(/\*\*\*(.+?)\*\*\*/gs, '<strong><em>$1</em></strong>');
+
+  // Bold
+  r = r.replace(/\*\*(.+?)\*\*/gs, '<strong class="font-semibold text-gray-900">$1</strong>');
+  r = r.replace(/__(.+?)__/gs, '<strong class="font-semibold text-gray-900">$1</strong>');
+
+  // Italic
+  r = r.replace(/\*([^*\n]+)\*/g, '<em class="italic">$1</em>');
+  r = r.replace(/_([^_\n]+)_/g, '<em class="italic">$1</em>');
+
+  // Strikethrough
+  r = r.replace(/~~(.+?)~~/gs, '<del class="line-through text-gray-400">$1</del>');
+
+  // Markdown links [text](url)
+  r = r.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline">$1</a>',
+  );
+
+  return r;
+}
+
+function processLines(lines: string[]): string {
+  let html = '';
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Headings
+    const h3 = line.match(/^### (.+)/);
+    if (h3) {
+      html += `<h3 class="text-base font-semibold text-gray-900 mt-4 mb-1.5">${inlineElements(h3[1])}</h3>`;
+      i++;
+      continue;
+    }
+    const h2 = line.match(/^## (.+)/);
+    if (h2) {
+      html += `<h2 class="text-lg font-semibold text-gray-900 mt-5 mb-2">${inlineElements(h2[1])}</h2>`;
+      i++;
+      continue;
+    }
+    const h1 = line.match(/^# (.+)/);
+    if (h1) {
+      html += `<h1 class="text-xl font-bold text-gray-900 mt-5 mb-2">${inlineElements(h1[1])}</h1>`;
+      i++;
+      continue;
+    }
+
+    // Thematic break
+    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line)) {
+      html += '<hr class="border-gray-200 my-4" />';
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith('> ')) {
+      const qLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith('> ')) {
+        qLines.push(inlineElements(lines[i].slice(2)));
+        i++;
+      }
+      html += `<blockquote class="border-l-4 border-gray-300 pl-4 my-3 text-gray-600 italic text-sm">${qLines.join('<br>')}</blockquote>`;
+      continue;
+    }
+
+    // Unordered list (incl. task list items)
+    if (/^[-*+] /.test(line)) {
+      let items = '';
+      while (i < lines.length && /^[-*+] /.test(lines[i])) {
+        const taskMatch = lines[i].match(/^[-*+] \[([ x])\] (.*)/i);
+        if (taskMatch) {
+          const checked = taskMatch[1].toLowerCase() === 'x';
+          items += `<li class="flex items-start gap-2 text-sm text-gray-700"><input type="checkbox" ${checked ? 'checked' : ''} disabled class="mt-0.5 shrink-0 accent-blue-500" /><span>${inlineElements(taskMatch[2])}</span></li>`;
+        } else {
+          items += `<li class="text-sm text-gray-700">${inlineElements(lines[i].slice(2))}</li>`;
+        }
+        i++;
+      }
+      html += `<ul class="list-disc list-outside pl-5 space-y-1 my-3">${items}</ul>`;
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\. /.test(line)) {
+      let items = '';
+      while (i < lines.length && /^\d+\. /.test(lines[i])) {
+        const text = lines[i].replace(/^\d+\. /, '');
+        items += `<li class="text-sm text-gray-700">${inlineElements(text)}</li>`;
+        i++;
+      }
+      html += `<ol class="list-decimal list-outside pl-5 space-y-1 my-3">${items}</ol>`;
+      continue;
+    }
+
+    // Empty line
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Paragraph – collect consecutive non-special lines
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !/^#{1,6} /.test(lines[i]) &&
+      !/^[-*+] /.test(lines[i]) &&
+      !/^\d+\. /.test(lines[i]) &&
+      !lines[i].startsWith('> ') &&
+      !/^(-{3,}|\*{3,}|_{3,})\s*$/.test(lines[i])
+    ) {
+      paraLines.push(inlineElements(lines[i]));
+      i++;
+    }
+    if (paraLines.length) {
+      html += `<p class="text-sm text-gray-700 leading-relaxed my-2">${paraLines.join('<br>')}</p>`;
+    }
+  }
+
+  return html;
+}
+
+/**
+ * Convert a Markdown string to a safe HTML string suitable for
+ * use with `dangerouslySetInnerHTML`. Only GitHub-flavoured
+ * Markdown constructs that appear in issue bodies are supported.
+ */
+export function parseMarkdownToHTML(markdown: string): string {
+  if (!markdown.trim()) return '';
+
+  // Split on fenced code blocks first so we never mangle code content.
+  const parts = markdown.split(/(```[\w]*\n[\s\S]*?```)/g);
+  let html = '';
+
+  for (const part of parts) {
+    const codeMatch = part.match(/^```([\w]*)\n([\s\S]*)```$/);
+    if (codeMatch) {
+      const lang = codeMatch[1];
+      const code = escapeHTML(codeMatch[2].trimEnd());
+      html += `<pre class="bg-gray-950 text-gray-100 rounded-lg p-3 overflow-x-auto my-3 text-xs font-mono leading-relaxed"${
+        lang ? ` data-lang="${escapeHTML(lang)}"` : ''
+      }>${code}</pre>`;
+    } else {
+      html += processLines(part.split('\n'));
+    }
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary

Implements the read-only issue view described in #21.

### What was changed

| File | Change |
|------|--------|
| `src/lib/markdown.ts` | **New** — lightweight Markdown → HTML converter (no extra npm dep). Supports headings, fenced code blocks, inline code, bold/italic/strikethrough, task lists, unordered/ordered lists, blockquotes, thematic breaks, and Markdown links. |
| `src/components/IssueReadModal.tsx` | **New** — read-only modal opened when a card is clicked. Renders the body via the Markdown renderer, shows metadata chips (wave, epic, status, assignees), and exposes an action toolbar in the top-right corner. |
| `src/components/IssueCard.tsx` | **Modified** — added `showReadModal` state; clicking the card body now opens `IssueReadModal`. The hover-action Edit/Close/Delete buttons remain and still bypass the read modal for quick access. URL deep-link logic now tracks the read modal instead of the edit modal. |
| `src/components/EditIssueModal.tsx` | **Modified** — added `initialTab?: 'description' \| 'ai'` prop so the read modal can open the edit form on either the Description or Implementation tab. |
| `README.md` | **Updated** — documented the new read-only issue view, action toolbar, Markdown support, and quick-edit fast path. |

### Acceptance criteria

- [x] Clicking an issue card from Grid or Kanban opens a read-only modal
- [x] Description is fully rendered as formatted Markdown (headers, lists, code blocks, task lists, links, bold/italic, etc.)
- [x] Action toolbar in the top-right corner of the modal
- [x] Toolbar contains Edit, Close, Delete, Describe with AI (✦), and Code with AI (⚡) buttons — AI buttons are conditional on the respective settings being configured
- [x] Edit opens `EditIssueModal` (description tab); ✦ opens it on the description tab; ⚡ opens it on the Implementation tab
- [x] Hover-action buttons on the card still work as before (fast path)

Closes #21