### PR TITLE
feat: Issue Reopen — inline reopen action for closed issues (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Labels are created automatically on GitHub when you add them through the **Epics
 - Grid/Kanban toggle in the toolbar
 - Create issues with pre-filled epic, wave, and status from any cell
 - **Read-only issue view** — clicking an issue card opens a formatted read-only modal (see below)
-- Edit, close, and permanently delete issues inline
+- Edit, close, reopen, and permanently delete issues inline
+- **Reopen closed issues** — a purple ↺ Reopen button replaces the Close button on closed issue cards (hover overlay) and in the read-only modal, sending a `PATCH` request to the GitHub Issues API to restore the issue to `open` state; the board updates immediately without a page refresh
 - Manage epic, wave, and status labels without leaving the app
 - Layout persisted to Firestore (optional — works fully offline)
 - Real-time sync with GitHub Issues API
@@ -61,7 +62,8 @@ Clicking any issue card in the Grid or Kanban view opens a **read-only modal** t
   | Button | Action |
   |--------|--------|
   | ✏️ Edit | Opens the edit modal (description tab) |
-  | ✓ Close | Closes the issue on GitHub |
+  | ✓ Close | Closes the issue on GitHub *(open issues only)* |
+  | ↺ Reopen | Reopens the issue on GitHub *(closed issues only)* |
   | 🗑 Delete | Permanently deletes the issue |
   | ✦ Describe with AI | Opens the edit modal to generate a description via Gemini (visible when Gemini is configured) |
   | ⚡ Code with AI | Opens the edit modal on the Implementation tab to start an AI coding session (visible when Anthropic is configured) |
@@ -69,7 +71,7 @@ Clicking any issue card in the Grid or Kanban view opens a **read-only modal** t
 
 ### Quick-edit fast path
 
-The hover overlay on each card still exposes **Edit**, **Close**, and **Delete** buttons directly, letting power users skip the read view and jump straight to the edit form.
+The hover overlay on each card still exposes **Edit**, **Close** (open issues) / **Reopen** (closed issues), and **Delete** buttons directly, letting power users skip the read view and jump straight to the action.
 
 ## Getting started
 
@@ -134,6 +136,16 @@ All values are stored in `localStorage` only.
 - **AI — code implementation:** Anthropic Claude Managed Agents API (direct `fetch`, beta `managed-agents-2026-04-01`)
 - **Markdown rendering:** Built-in lightweight renderer (`src/lib/markdown.ts`) — no extra dependency
 - **Build:** Vite
+
+## Changelog
+
+### Issue Reopen (#30)
+
+Closed issues can now be reopened directly from the board without switching to the native GitHub UI:
+
+- **IssueCard (hover overlay):** The green ✓ Close button is replaced by a purple ↺ Reopen button when the issue is already closed. Clicking it confirms and sends a `PATCH /repos/{owner}/{repo}/issues/{number}` request with `state: open`.
+- **IssueReadModal (action toolbar):** A purple ↺ Reopen button appears in place of the Close button for closed issues, giving the same action from the detailed view.
+- **State management (`appStore`):** A new `reopenIssue(number)` action updates the issue's `state` to `open` in the local Zustand cache immediately. If the issue was previously closed inline (and therefore removed from the layout), it is automatically restored to the backlog so it reappears on the Grid and Kanban views — preserving all existing `e_` and `w_` labels.
 
 ## Troubleshooting
 

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export default function IssueCard({ issue }: Props) {
-  const { closeIssue, deleteIssue } = useAppStore();
+  const { closeIssue, deleteIssue, reopenIssue } = useAppStore();
 
   // Read-only view — opens when the card body is clicked or when the URL
   // already points to this issue (deep-link / page-refresh support).
@@ -76,6 +76,14 @@ export default function IssueCard({ issue }: Props) {
     if (!confirm(`Close issue #${issue.number}?`)) return;
     setBusy(true);
     try { await closeIssue(issue.number); } catch { setBusy(false); }
+  }
+
+  async function handleReopen(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!confirm(`Reopen issue #${issue.number}?`)) return;
+    setBusy(true);
+    try { await reopenIssue(issue.number); } catch { setBusy(false); }
+    setBusy(false);
   }
 
   async function handleDelete(e: React.MouseEvent) {
@@ -169,15 +177,30 @@ export default function IssueCard({ issue }: Props) {
                 <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
               </svg>
             </button>
-            <button
-              onClick={handleClose}
-              title="Close issue"
-              className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-            </button>
+
+            {/* Close (open issues) / Reopen (closed issues) */}
+            {issue.state === 'open' ? (
+              <button
+                onClick={handleClose}
+                title="Close issue"
+                className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </button>
+            ) : (
+              <button
+                onClick={handleReopen}
+                title="Reopen issue"
+                className="text-purple-600 p-1 rounded-md border border-purple-200 bg-purple-50 hover:bg-purple-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+                </svg>
+              </button>
+            )}
+
             <button
               onClick={handleDelete}
               title="Delete issue permanently"

--- a/src/components/IssueReadModal.tsx
+++ b/src/components/IssueReadModal.tsx
@@ -12,11 +12,11 @@ interface Props {
 /**
  * Read-only view of a GitHub issue.
  * Renders the description as formatted Markdown and exposes an action
- * toolbar (Edit, Close, Delete, Describe with AI, Code with AI) in the
+ * toolbar (Edit, Close/Reopen, Delete, Describe with AI, Code with AI) in the
  * top-right corner.
  */
 export default function IssueReadModal({ issue, onClose }: Props) {
-  const { closeIssue, deleteIssue, projects, projectIssues } = useAppStore();
+  const { closeIssue, deleteIssue, reopenIssue, projects, projectIssues } = useAppStore();
 
   const [showEdit, setShowEdit] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -43,6 +43,18 @@ export default function IssueReadModal({ issue, onClose }: Props) {
     setBusy(true);
     try {
       await closeIssue(issue.number);
+      onClose();
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  async function handleReopen(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!confirm(`Reopen issue #${issue.number}?`)) return;
+    setBusy(true);
+    try {
+      await reopenIssue(issue.number);
       onClose();
     } catch {
       setBusy(false);
@@ -178,6 +190,19 @@ export default function IssueReadModal({ issue, onClose }: Props) {
               >
                 <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </button>
+            )}
+
+            {/* Reopen issue (only when closed) */}
+            {issue.state === 'closed' && (
+              <button
+                onClick={handleReopen}
+                title="Reopen issue"
+                className="p-1.5 text-purple-600 rounded-lg border border-purple-200 bg-purple-50 hover:bg-purple-100 transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
                 </svg>
               </button>
             )}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -46,6 +46,7 @@ interface AppState {
   ) => Promise<void>;
   updateIssue: (number: number, title: string, body: string, milestoneNumber?: number | null) => Promise<void>;
   closeIssue: (number: number) => Promise<void>;
+  reopenIssue: (number: number) => Promise<void>;
   deleteIssue: (number: number, nodeId: string) => Promise<void>;
   fetchProjects: () => Promise<void>;
   createProject: (title: string, description: string) => Promise<void>;
@@ -406,6 +407,34 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     set({ issues: issues.filter((i) => i.number !== number), layout: newLayout });
     saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
+  },
+
+  reopenIssue: async (number) => {
+    const { token, owner, repo, issues, layout } = get();
+    const octokit = new Octokit({ auth: token });
+    await octokit.rest.issues.update({ owner, repo, issue_number: number, state: 'open' });
+
+    // Update the issue's state to open in the local cache
+    const updatedIssues = issues.map((i) =>
+      i.number === number ? { ...i, state: 'open' as const } : i,
+    );
+
+    // If the issue was removed from the layout when it was closed inline,
+    // add it back to the backlog so it reappears on the board
+    const allInLayout = new Set(Object.values(layout.storyOrder).flat());
+    let newLayout = layout;
+    if (!allInLayout.has(number)) {
+      newLayout = {
+        ...layout,
+        storyOrder: {
+          ...layout.storyOrder,
+          backlog: [...(layout.storyOrder.backlog ?? []), number],
+        },
+      };
+      saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
+    }
+
+    set({ issues: updatedIssues, layout: newLayout });
   },
 
   deleteIssue: async (number, nodeId) => {


### PR DESCRIPTION
## Summary

This PR implements the **Issue Reopen** feature requested in #30. Users can now reopen a closed issue directly from the GitHub Story Map board without context-switching to the native GitHub interface.

---

## Changes

### `src/store/appStore.ts`
- Added `reopenIssue: (number: number) => Promise<void>` to the `AppState` interface.
- Implemented the `reopenIssue` action:
  - Sends a `PATCH` request via Octokit to change the issue `state` from `closed` → `open`.
  - Optimistically updates the issue's `state` in the local Zustand cache.
  - If the issue was previously removed from the board layout when it was closed inline, it is automatically restored to the **backlog** — preserving its existing `e_` and `w_` labels so it reappears in the correct Grid/Kanban position.

### `src/components/IssueCard.tsx`
- Imported `reopenIssue` from the app store.
- Added `handleReopen` handler (confirm dialog → call `reopenIssue`).
- The Close ✓ button is now **conditionally rendered**: shown only for `open` issues. For `closed` issues it is replaced by a purple ↺ **Reopen** button in the hover overlay.

### `src/components/IssueReadModal.tsx`
- Imported `reopenIssue` from the app store.
- Added `handleReopen` handler (confirm dialog → call `reopenIssue` → close modal).
- Added a purple ↺ **Reopen** button to the action toolbar, shown only when `issue.state === 'closed'` (complementing the existing Close button shown only when `issue.state === 'open'`).

### `README.md`
- Updated the **Features** list to mention the reopen action.
- Updated the **Read-only issue view** action toolbar table to document the new Reopen button.
- Updated the **Quick-edit fast path** section.
- Added a **Changelog** section with a detailed description of the change.

---

## Acceptance criteria

- [x] A "Reopen" action is visible and accessible on closed issues in the Grid view, Kanban view, and the read-only issue modal.
- [x] Clicking "Reopen" sends a `PATCH` request to the GitHub Issues API to change the issue state to `open`.
- [x] The UI reacts immediately to the state change — no hard page refresh required.
- [x] Reopening retains existing `e_` and `w_` labels so the issue remains in the correct matrix intersection.

Closes #30