### PR TITLE
Kanban View by Wave: native GitHub Project status columns

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import EpicsView from './components/EpicsView';
 import SettingsView from './components/SettingsView';
 
 export default function App() {
-  const { token, owner, repo, issues, loading, error, fetchIssues, fetchLabels, fetchProjects, fetchMilestones, view } = useAppStore();
+  const { token, owner, repo, issues, loading, error, fetchIssues, fetchLabels, fetchProjects, fetchMilestones, fetchAllProjectStatuses, view } = useAppStore();
 
   const isConfigured = Boolean(token && owner && repo);
 
@@ -17,7 +17,7 @@ export default function App() {
     if (isConfigured && issues.length === 0) {
       fetchIssues();
       fetchLabels();
-      fetchProjects();
+      fetchProjects().then(() => fetchAllProjectStatuses());
       fetchMilestones();
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,8 +3,10 @@ import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues } = useAppStore();
+  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, projects, kanbanProjectId, setKanbanProject } = useAppStore();
   const [showCreate, setShowCreate] = useState(false);
+
+  const openProjects = projects.filter((p) => !p.closed);
 
   return (
     <>
@@ -29,6 +31,21 @@ export default function Header() {
               </button>
             ))}
           </div>
+
+          {/* Kanban project selector */}
+          {view === 'kanban' && openProjects.length > 0 && (
+            <select
+              value={kanbanProjectId ?? ''}
+              onChange={(e) => setKanbanProject(e.target.value || null)}
+              disabled={loading}
+              className="ml-3 text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-400 disabled:opacity-50"
+            >
+              <option value="" disabled>Select project…</option>
+              {openProjects.map((p) => (
+                <option key={p.id} value={p.id}>{p.title}</option>
+              ))}
+            </select>
+          )}
 
           {/* Action buttons */}
           <div className="flex items-center gap-1">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,7 @@ export default function Header() {
             <div className="relative group">
               <button
                 onClick={toggleShowClosedIssues}
-                className="p-2 rounded-lg bg-green-600 text-white hover:bg-green-700 transition-colors"
+                className="p-2 rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-colors"
               >
                 {showClosedIssues ? (
                   <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,10 +3,8 @@ import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, projects, kanbanProjectId, setKanbanProject } = useAppStore();
+  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone } = useAppStore();
   const [showCreate, setShowCreate] = useState(false);
-
-  const openProjects = projects.filter((p) => !p.closed);
 
   return (
     <>
@@ -32,17 +30,17 @@ export default function Header() {
             ))}
           </div>
 
-          {/* Kanban project selector */}
-          {view === 'kanban' && openProjects.length > 0 && (
+          {/* Kanban wave selector */}
+          {view === 'kanban' && milestones.length > 0 && (
             <select
-              value={kanbanProjectId ?? ''}
-              onChange={(e) => setKanbanProject(e.target.value || null)}
+              value={kanbanMilestoneNumber ?? ''}
+              onChange={(e) => setKanbanMilestone(e.target.value ? Number(e.target.value) : null)}
               disabled={loading}
               className="ml-3 text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-400 disabled:opacity-50"
             >
-              <option value="" disabled>Select project…</option>
-              {openProjects.map((p) => (
-                <option key={p.id} value={p.id}>{p.title}</option>
+              <option value="">All Waves</option>
+              {milestones.map((m) => (
+                <option key={m.number} value={m.number}>{m.title}</option>
               ))}
             </select>
           )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone } = useAppStore();
+  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone } = useAppStore();
   const [showCreate, setShowCreate] = useState(false);
 
   return (
@@ -88,7 +88,7 @@ export default function Header() {
             {/* Sync */}
             <div className="relative group">
               <button
-                onClick={() => { fetchIssues(); fetchProjects(); fetchMilestones(); }}
+                onClick={() => { fetchIssues(); fetchProjects().then(() => fetchAllProjectStatuses()); fetchMilestones(); }}
                 disabled={loading}
                 className="p-2 rounded-lg bg-orange-500 text-white hover:bg-orange-600 disabled:opacity-40 transition-colors"
               >

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -61,9 +61,9 @@ export default function IssueCard({ issue }: Props) {
   }, [showReadModal, issue.number]);
 
   const nativeStatus = kanbanIssueStatuses[issue.number] ?? (issue.state === 'open' ? 'Todo' : null);
-  const badgeStyle = issue.state === 'closed'
-    ? ghStyle('GREEN')
-    : ghStyle(nativeStatus ? (kanbanStatusColors[nativeStatus] ?? 'GRAY') : 'GRAY');
+  const badgeStyle = nativeStatus
+    ? ghStyle(kanbanStatusColors[nativeStatus] ?? 'GRAY')
+    : ghStyle(issue.state === 'closed' ? 'GREEN' : 'GRAY');
 
   function onCardEnter() {
     setHovered(true);

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -16,8 +16,23 @@ interface Props {
   showStatus?: boolean;
 }
 
+const GH_COLOR_STYLE: Record<string, [string, string, string]> = {
+  GRAY:   ['#f9fafb', '#6b7280', '#e5e7eb'],
+  BLUE:   ['#eff6ff', '#2563eb', '#bfdbfe'],
+  GREEN:  ['#f0fdf4', '#16a34a', '#bbf7d0'],
+  YELLOW: ['#fefce8', '#854d0e', '#fde047'],
+  ORANGE: ['#fff7ed', '#c2410c', '#fed7aa'],
+  RED:    ['#fef2f2', '#dc2626', '#fecaca'],
+  PINK:   ['#fdf2f8', '#be185d', '#fbcfe8'],
+  PURPLE: ['#faf5ff', '#7e22ce', '#e9d5ff'],
+};
+function ghStyle(color: string): React.CSSProperties {
+  const [bg, text, border] = GH_COLOR_STYLE[color] ?? GH_COLOR_STYLE.GRAY;
+  return { backgroundColor: bg, color: text, border: `1px solid ${border}` };
+}
+
 export default function IssueCard({ issue }: Props) {
-  const { closeIssue, deleteIssue, reopenIssue } = useAppStore();
+  const { closeIssue, deleteIssue, reopenIssue, kanbanIssueStatuses, kanbanStatusColors } = useAppStore();
 
   // Read-only view — opens when the card body is clicked or when the URL
   // already points to this issue (deep-link / page-refresh support).
@@ -45,12 +60,10 @@ export default function IssueCard({ issue }: Props) {
     }
   }, [showReadModal, issue.number]);
 
-  const statusLabel = issue.labels.find(l => l.name.startsWith('s_'));
-  const statusName = statusLabel ? statusLabel.name.slice(2) : null;
-
-  const badgeStyle: React.CSSProperties = issue.state === 'open'
-    ? { backgroundColor: '#eff6ff', color: '#2563eb', border: '1px solid #bfdbfe' }
-    : { backgroundColor: '#f0fdf4', color: '#16a34a', border: '1px solid #bbf7d0' };
+  const nativeStatus = kanbanIssueStatuses[issue.number] ?? (issue.state === 'open' ? 'Todo' : null);
+  const badgeStyle = issue.state === 'closed'
+    ? ghStyle('GREEN')
+    : ghStyle(nativeStatus ? (kanbanStatusColors[nativeStatus] ?? 'GRAY') : 'GRAY');
 
   function onCardEnter() {
     setHovered(true);
@@ -136,7 +149,7 @@ export default function IssueCard({ issue }: Props) {
 
               {showBadgeTip && (
                 <div className="absolute bottom-full left-0 mb-1.5 z-30 bg-gray-900 text-white text-xs rounded-md px-2.5 py-2 shadow-lg whitespace-nowrap min-w-max">
-                  {statusName && <div className="font-semibold mb-1">{statusName}</div>}
+                  {nativeStatus && <div className="font-semibold mb-1">{nativeStatus}</div>}
                   <a
                     href={issue.html_url}
                     target="_blank"

--- a/src/components/IssueReadModal.tsx
+++ b/src/components/IssueReadModal.tsx
@@ -51,8 +51,8 @@ export default function IssueReadModal({ issue, onClose }: Props) {
   const renderedBody = displayBody.trim() ? parseMarkdownToHTML(displayBody) : null;
 
   const nativeStatus = kanbanIssueStatuses[issue.number] ?? (issue.state === 'open' ? 'Todo' : null);
-  const statusDisplayLabel = issue.state === 'closed' ? 'Closed' : (nativeStatus ?? 'Todo');
-  const statusColor = issue.state === 'closed' ? 'GREEN' : (nativeStatus ? (kanbanStatusColors[nativeStatus] ?? 'GRAY') : 'GRAY');
+  const statusDisplayLabel = nativeStatus ?? (issue.state === 'closed' ? 'Closed' : 'Todo');
+  const statusColor = nativeStatus ? (kanbanStatusColors[nativeStatus] ?? 'GRAY') : (issue.state === 'closed' ? 'GREEN' : 'GRAY');
 
   async function handleClose(e: React.MouseEvent) {
     e.stopPropagation();

--- a/src/components/IssueReadModal.tsx
+++ b/src/components/IssueReadModal.tsx
@@ -15,8 +15,23 @@ interface Props {
  * toolbar (Edit, Close/Reopen, Delete, Describe with AI, Code with AI) in the
  * top-right corner.
  */
+const GH_COLOR_STYLE: Record<string, [string, string, string]> = {
+  GRAY:   ['#f9fafb', '#6b7280', '#e5e7eb'],
+  BLUE:   ['#eff6ff', '#2563eb', '#bfdbfe'],
+  GREEN:  ['#f0fdf4', '#16a34a', '#bbf7d0'],
+  YELLOW: ['#fefce8', '#854d0e', '#fde047'],
+  ORANGE: ['#fff7ed', '#c2410c', '#fed7aa'],
+  RED:    ['#fef2f2', '#dc2626', '#fecaca'],
+  PINK:   ['#fdf2f8', '#be185d', '#fbcfe8'],
+  PURPLE: ['#faf5ff', '#7e22ce', '#e9d5ff'],
+};
+function ghStyle(color: string): React.CSSProperties {
+  const [bg, text, border] = GH_COLOR_STYLE[color] ?? GH_COLOR_STYLE.GRAY;
+  return { backgroundColor: bg, color: text, border: `1px solid ${border}` };
+}
+
 export default function IssueReadModal({ issue, onClose }: Props) {
-  const { closeIssue, deleteIssue, reopenIssue, projects, projectIssues } = useAppStore();
+  const { closeIssue, deleteIssue, reopenIssue, projects, projectIssues, kanbanIssueStatuses, kanbanStatusColors } = useAppStore();
 
   const [showEdit, setShowEdit] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -35,7 +50,9 @@ export default function IssueReadModal({ issue, onClose }: Props) {
 
   const renderedBody = displayBody.trim() ? parseMarkdownToHTML(displayBody) : null;
 
-  const statusLabel = issue.labels.find((l) => l.name.startsWith('s_'));
+  const nativeStatus = kanbanIssueStatuses[issue.number] ?? (issue.state === 'open' ? 'Todo' : null);
+  const statusDisplayLabel = issue.state === 'closed' ? 'Closed' : (nativeStatus ?? 'Todo');
+  const statusColor = issue.state === 'closed' ? 'GREEN' : (nativeStatus ? (kanbanStatusColors[nativeStatus] ?? 'GRAY') : 'GRAY');
 
   async function handleClose(e: React.MouseEvent) {
     e.stopPropagation();
@@ -93,24 +110,15 @@ export default function IssueReadModal({ issue, onClose }: Props) {
           {/* Left: status, number, title, metadata */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              {/* Open / Closed badge */}
+              {/* Native project status badge */}
               <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${
-                  issue.state === 'open'
-                    ? 'bg-blue-50 text-blue-700 border-blue-200'
-                    : 'bg-green-50 text-green-700 border-green-200'
-                }`}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                style={ghStyle(statusColor)}
               >
-                {issue.state === 'open' ? (
-                  <svg className="w-2 h-2" fill="currentColor" viewBox="0 0 8 8">
-                    <circle cx="4" cy="4" r="4" />
-                  </svg>
-                ) : (
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                  </svg>
-                )}
-                {issue.state === 'open' ? 'Open' : 'Closed'}
+                <svg className="w-2 h-2" fill="currentColor" viewBox="0 0 8 8">
+                  <circle cx="4" cy="4" r="4" />
+                </svg>
+                {statusDisplayLabel}
               </span>
 
               {/* Issue number → GitHub link */}
@@ -140,11 +148,6 @@ export default function IssueReadModal({ issue, onClose }: Props) {
               {epic && (
                 <span className="text-xs text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full border border-blue-200">
                   ⬡ {epic.title}
-                </span>
-              )}
-              {statusLabel && (
-                <span className="text-xs text-green-700 bg-green-50 px-2 py-0.5 rounded-full border border-green-200">
-                  ◆ {statusLabel.name.slice(2)}
                 </span>
               )}
               {issue.assignees.length > 0 && (

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -49,16 +49,13 @@ export default function KanbanView() {
   const {
     issues, milestones, statusLabels, layout, showClosedIssues,
     moveIssueInKanban, moveIssueInKanbanNative, columnWidths, setColumnWidth,
-    projects, projectIssues,
-    kanbanProjectId, kanbanStatusField, kanbanIssueStatuses, setKanbanProject,
-    loading,
+    projectIssues,
+    kanbanProjectId, kanbanStatusField, kanbanIssueStatuses,
   } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
-  const [projectLoading, setProjectLoading] = useState(false);
 
   const isProjectMode = kanbanProjectId !== null;
-  const openProjects = projects.filter((p) => !p.closed);
 
   // In project mode, columns come from the project's Status field options.
   // In label mode, columns come from s_* labels.
@@ -112,41 +109,8 @@ export default function KanbanView() {
     });
   }
 
-  async function handleProjectChange(projectId: string) {
-    setProjectLoading(true);
-    try {
-      await setKanbanProject(projectId || null);
-    } catch (err) {
-      setMoveError(err instanceof Error ? err.message : 'Failed to load project');
-      setTimeout(() => setMoveError(null), 4000);
-    } finally {
-      setProjectLoading(false);
-    }
-  }
-
   return (
     <>
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-100 bg-white">
-        <span className="text-xs font-medium text-gray-500 whitespace-nowrap">Project</span>
-        <select
-          value={kanbanProjectId ?? ''}
-          onChange={(e) => handleProjectChange(e.target.value)}
-          disabled={loading || projectLoading}
-          className="text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-400 min-w-48 disabled:opacity-50"
-        >
-          <option value="">Label-based (s_ labels)</option>
-          {openProjects.map((p) => (
-            <option key={p.id} value={p.id}>{p.title}</option>
-          ))}
-        </select>
-        {projectLoading && (
-          <span className="text-xs text-gray-400">Loading…</span>
-        )}
-        {isProjectMode && !kanbanStatusField && !projectLoading && (
-          <span className="text-xs text-amber-600">This project has no Status field — showing all issues as unstatused.</span>
-        )}
-      </div>
-
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className="flex-1 overflow-auto h-full">
           <table className="border-collapse">

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -11,8 +11,6 @@ function getStatusLabel(issue: GitHubIssue): string | null {
   return label ? label.name.slice(2) : null;
 }
 
-// Encode/decode cell droppable IDs for the kanban.
-// Format: "k:{status|none}:{milestoneNumber|none}"
 function kanbanCellId(status: string, milestoneNumber: number | null): string {
   return `k:${status || 'none'}:${milestoneNumber ?? 'none'}`;
 }
@@ -43,36 +41,54 @@ function sortedMilestones(milestones: GitHubMilestone[], milestoneOrder: number[
   });
 }
 
-/**
- * Returns the localStorage key used for a given Kanban status column.
- * Empty string ("No Status") maps to the sentinel '__no_status__'.
- */
 function kanbanColKey(status: string): string {
   return status === '' ? '__no_status__' : status;
 }
 
 export default function KanbanView() {
-  const { issues, milestones, statusLabels, layout, showClosedIssues, moveIssueInKanban, columnWidths, setColumnWidth } = useAppStore();
+  const {
+    issues, milestones, statusLabels, layout, showClosedIssues,
+    moveIssueInKanban, moveIssueInKanbanNative, columnWidths, setColumnWidth,
+    projects, projectIssues,
+    kanbanProjectId, kanbanStatusField, kanbanIssueStatuses, setKanbanProject,
+    loading,
+  } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
+  const [projectLoading, setProjectLoading] = useState(false);
 
-  // null sentinel = "No Milestone" swimlane — always last
+  const isProjectMode = kanbanProjectId !== null;
+  const openProjects = projects.filter((p) => !p.closed);
+
+  // In project mode, columns come from the project's Status field options.
+  // In label mode, columns come from s_* labels.
+  const cols: string[] = isProjectMode && kanbanStatusField
+    ? [...kanbanStatusField.options.map((o) => o.name), '']
+    : [...statusLabels, ''];
+
   const groups: (GitHubMilestone | null)[] = [...sortedMilestones(milestones, layout.milestoneOrder), null];
-  // '' sentinel = "No Status" column
-  const cols = [...statusLabels, ''];
 
-  /** Returns the stored (or default) width for a given status column. */
   const colK = (status: string) => columnWidths[kanbanColKey(status)] ?? KANBAN_DEFAULT_WIDTH;
 
-  const visibleIssues = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
+  const allVisible = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
+
+  // In project mode, only show issues that belong to the selected project.
+  const visibleIssues = isProjectMode
+    ? allVisible.filter((i) => (projectIssues[kanbanProjectId] ?? []).includes(i.number))
+    : allVisible;
 
   function cellIssues(milestoneNumber: number | null, status: string): GitHubIssue[] {
     return visibleIssues.filter((issue) => {
       const mMatch = milestoneNumber === null
         ? issue.milestone === null
         : issue.milestone?.number === milestoneNumber;
-      const sLabel = getStatusLabel(issue);
-      const statusMatch = status === '' ? sLabel === null : sLabel === status;
+      const statusMatch = isProjectMode
+        ? status === ''
+          ? !kanbanIssueStatuses[issue.number]
+          : kanbanIssueStatuses[issue.number] === status
+        : status === ''
+          ? getStatusLabel(issue) === null
+          : getStatusLabel(issue) === status;
       return mMatch && statusMatch;
     });
   }
@@ -85,15 +101,52 @@ export default function KanbanView() {
     const issueNumber = Number(draggableId.slice(2));
     const src = parseKanbanCell(source.droppableId);
     const dst = parseKanbanCell(destination.droppableId);
-    moveIssueInKanban(issueNumber, src.status, dst.status, src.milestoneNumber, dst.milestoneNumber)
-      .catch((err) => {
-        setMoveError(err instanceof Error ? err.message : 'Failed to move issue');
-        setTimeout(() => setMoveError(null), 4000);
-      });
+
+    const action = isProjectMode
+      ? moveIssueInKanbanNative(issueNumber, src.status, dst.status, src.milestoneNumber, dst.milestoneNumber)
+      : moveIssueInKanban(issueNumber, src.status, dst.status, src.milestoneNumber, dst.milestoneNumber);
+
+    action.catch((err) => {
+      setMoveError(err instanceof Error ? err.message : 'Failed to move issue');
+      setTimeout(() => setMoveError(null), 4000);
+    });
+  }
+
+  async function handleProjectChange(projectId: string) {
+    setProjectLoading(true);
+    try {
+      await setKanbanProject(projectId || null);
+    } catch (err) {
+      setMoveError(err instanceof Error ? err.message : 'Failed to load project');
+      setTimeout(() => setMoveError(null), 4000);
+    } finally {
+      setProjectLoading(false);
+    }
   }
 
   return (
     <>
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-100 bg-white">
+        <span className="text-xs font-medium text-gray-500 whitespace-nowrap">Project</span>
+        <select
+          value={kanbanProjectId ?? ''}
+          onChange={(e) => handleProjectChange(e.target.value)}
+          disabled={loading || projectLoading}
+          className="text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-400 min-w-48 disabled:opacity-50"
+        >
+          <option value="">Label-based (s_ labels)</option>
+          {openProjects.map((p) => (
+            <option key={p.id} value={p.id}>{p.title}</option>
+          ))}
+        </select>
+        {projectLoading && (
+          <span className="text-xs text-gray-400">Loading…</span>
+        )}
+        {isProjectMode && !kanbanStatusField && !projectLoading && (
+          <span className="text-xs text-amber-600">This project has no Status field — showing all issues as unstatused.</span>
+        )}
+      </div>
+
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className="flex-1 overflow-auto h-full">
           <table className="border-collapse">

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -6,11 +6,6 @@ import IssueCard from './IssueCard';
 import CreateIssueModal from './CreateIssueModal';
 import ResizableHeader, { KANBAN_DEFAULT_WIDTH } from './ResizableHeader';
 
-function getStatusLabel(issue: GitHubIssue): string | null {
-  const label = issue.labels.find((l) => l.name.startsWith('s_'));
-  return label ? label.name.slice(2) : null;
-}
-
 // Format: "k:{status|none}:{projectId|__no_epic__}"
 // GitHub node IDs are base64 and never contain colons, so lastIndexOf(':') is safe.
 function kanbanCellId(status: string, projectId: string | null): string {
@@ -49,14 +44,15 @@ function kanbanColKey(status: string): string {
 
 export default function KanbanView() {
   const {
-    issues, statusLabels, layout, showClosedIssues,
+    issues, layout, showClosedIssues,
     moveIssueInKanbanByProject, columnWidths, setColumnWidth,
     projects, projectIssues, kanbanMilestoneNumber,
+    kanbanStatusColumns, kanbanIssueStatuses,
   } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
 
-  const cols = [...statusLabels, ''];
+  const cols = [...kanbanStatusColumns, ''];
   const colK = (status: string) => columnWidths[kanbanColKey(status)] ?? KANBAN_DEFAULT_WIDTH;
 
   const openProjects = projects.filter((p) => !p.closed);
@@ -75,8 +71,8 @@ export default function KanbanView() {
       const pMatch = projectId === null
         ? !allProjectIssueNumbers.has(issue.number)
         : (projectIssues[projectId] ?? []).includes(issue.number);
-      const sLabel = getStatusLabel(issue);
-      const statusMatch = status === '' ? sLabel === null : sLabel === status;
+      const issueStatus = kanbanIssueStatuses[issue.number] ?? null;
+      const statusMatch = status === '' ? issueStatus === null : issueStatus === status;
       return pMatch && statusMatch;
     });
   }

--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { DragDropContext, Droppable, Draggable, type DropResult } from '@hello-pangea/dnd';
 import { useAppStore } from '../store/appStore';
-import type { GitHubIssue, GitHubMilestone } from '../types';
+import type { GitHubIssue, GitHubProject } from '../types';
 import IssueCard from './IssueCard';
 import CreateIssueModal from './CreateIssueModal';
 import ResizableHeader, { KANBAN_DEFAULT_WIDTH } from './ResizableHeader';
@@ -11,29 +11,31 @@ function getStatusLabel(issue: GitHubIssue): string | null {
   return label ? label.name.slice(2) : null;
 }
 
-function kanbanCellId(status: string, milestoneNumber: number | null): string {
-  return `k:${status || 'none'}:${milestoneNumber ?? 'none'}`;
+// Format: "k:{status|none}:{projectId|__no_epic__}"
+// GitHub node IDs are base64 and never contain colons, so lastIndexOf(':') is safe.
+function kanbanCellId(status: string, projectId: string | null): string {
+  return `k:${status || 'none'}:${projectId ?? '__no_epic__'}`;
 }
-function parseKanbanCell(id: string): { status: string | null; milestoneNumber: number | null } {
+function parseKanbanCell(id: string): { status: string | null; projectId: string | null } {
   const first = id.indexOf(':');
   const last = id.lastIndexOf(':');
   const statusPart = id.slice(first + 1, last);
-  const milestonePart = id.slice(last + 1);
+  const projectPart = id.slice(last + 1);
   return {
     status: statusPart === 'none' ? null : statusPart,
-    milestoneNumber: milestonePart === 'none' ? null : Number(milestonePart),
+    projectId: projectPart === '__no_epic__' ? null : projectPart,
   };
 }
 
 interface CellKey {
-  milestoneNumber: number | null;
+  projectId: string | null;
   statusLabel: string;
 }
 
-function sortedMilestones(milestones: GitHubMilestone[], milestoneOrder: number[]): GitHubMilestone[] {
-  return [...milestones].sort((a, b) => {
-    const ai = (milestoneOrder ?? []).indexOf(a.number);
-    const bi = (milestoneOrder ?? []).indexOf(b.number);
+function sortedProjects(projects: GitHubProject[], epicOrder: number[]): GitHubProject[] {
+  return [...projects].sort((a, b) => {
+    const ai = epicOrder.indexOf(a.number);
+    const bi = epicOrder.indexOf(b.number);
     if (ai === -1 && bi === -1) return 0;
     if (ai === -1) return 1;
     if (bi === -1) return -1;
@@ -47,46 +49,35 @@ function kanbanColKey(status: string): string {
 
 export default function KanbanView() {
   const {
-    issues, milestones, statusLabels, layout, showClosedIssues,
-    moveIssueInKanban, moveIssueInKanbanNative, columnWidths, setColumnWidth,
-    projectIssues,
-    kanbanProjectId, kanbanStatusField, kanbanIssueStatuses,
+    issues, statusLabels, layout, showClosedIssues,
+    moveIssueInKanbanByProject, columnWidths, setColumnWidth,
+    projects, projectIssues, kanbanMilestoneNumber,
   } = useAppStore();
   const [createCell, setCreateCell] = useState<CellKey | null>(null);
   const [moveError, setMoveError] = useState<string | null>(null);
 
-  const isProjectMode = kanbanProjectId !== null;
-
-  // In project mode, columns come from the project's Status field options.
-  // In label mode, columns come from s_* labels.
-  const cols: string[] = isProjectMode && kanbanStatusField
-    ? [...kanbanStatusField.options.map((o) => o.name), '']
-    : [...statusLabels, ''];
-
-  const groups: (GitHubMilestone | null)[] = [...sortedMilestones(milestones, layout.milestoneOrder), null];
-
+  const cols = [...statusLabels, ''];
   const colK = (status: string) => columnWidths[kanbanColKey(status)] ?? KANBAN_DEFAULT_WIDTH;
 
-  const allVisible = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
+  const openProjects = projects.filter((p) => !p.closed);
+  // null sentinel = "No Epic" row — always last
+  const groups: (GitHubProject | null)[] = [...sortedProjects(openProjects, layout.epicOrder), null];
 
-  // In project mode, only show issues that belong to the selected project.
-  const visibleIssues = isProjectMode
-    ? allVisible.filter((i) => (projectIssues[kanbanProjectId] ?? []).includes(i.number))
+  const allProjectIssueNumbers = new Set(Object.values(projectIssues).flat());
+
+  const allVisible = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
+  const visibleIssues = kanbanMilestoneNumber !== null
+    ? allVisible.filter((i) => i.milestone?.number === kanbanMilestoneNumber)
     : allVisible;
 
-  function cellIssues(milestoneNumber: number | null, status: string): GitHubIssue[] {
+  function cellIssues(projectId: string | null, status: string): GitHubIssue[] {
     return visibleIssues.filter((issue) => {
-      const mMatch = milestoneNumber === null
-        ? issue.milestone === null
-        : issue.milestone?.number === milestoneNumber;
-      const statusMatch = isProjectMode
-        ? status === ''
-          ? !kanbanIssueStatuses[issue.number]
-          : kanbanIssueStatuses[issue.number] === status
-        : status === ''
-          ? getStatusLabel(issue) === null
-          : getStatusLabel(issue) === status;
-      return mMatch && statusMatch;
+      const pMatch = projectId === null
+        ? !allProjectIssueNumbers.has(issue.number)
+        : (projectIssues[projectId] ?? []).includes(issue.number);
+      const sLabel = getStatusLabel(issue);
+      const statusMatch = status === '' ? sLabel === null : sLabel === status;
+      return pMatch && statusMatch;
     });
   }
 
@@ -99,14 +90,11 @@ export default function KanbanView() {
     const src = parseKanbanCell(source.droppableId);
     const dst = parseKanbanCell(destination.droppableId);
 
-    const action = isProjectMode
-      ? moveIssueInKanbanNative(issueNumber, src.status, dst.status, src.milestoneNumber, dst.milestoneNumber)
-      : moveIssueInKanban(issueNumber, src.status, dst.status, src.milestoneNumber, dst.milestoneNumber);
-
-    action.catch((err) => {
-      setMoveError(err instanceof Error ? err.message : 'Failed to move issue');
-      setTimeout(() => setMoveError(null), 4000);
-    });
+    moveIssueInKanbanByProject(issueNumber, src.status, dst.status, src.projectId, dst.projectId)
+      .catch((err) => {
+        setMoveError(err instanceof Error ? err.message : 'Failed to move issue');
+        setTimeout(() => setMoveError(null), 4000);
+      });
   }
 
   return (
@@ -131,30 +119,30 @@ export default function KanbanView() {
               </tr>
             </thead>
             <tbody>
-              {groups.map((milestone) => (
+              {groups.map((project) => (
                 <>
-                  <tr key={`${milestone?.number ?? 'no-milestone'}-header`}>
+                  <tr key={`${project?.id ?? 'no-epic'}-header`}>
                     <td
                       colSpan={cols.length}
                       className="sticky left-0 bg-purple-50 border border-gray-200 px-4 py-2 text-xs font-semibold text-purple-900 uppercase tracking-wide"
                     >
-                      {milestone
-                        ? milestone.title
-                        : <span className="text-purple-400 font-normal italic normal-case tracking-normal">No Wave</span>}
+                      {project
+                        ? project.title
+                        : <span className="text-purple-400 font-normal italic normal-case tracking-normal">No Epic</span>}
                     </td>
                   </tr>
 
-                  <tr key={`${milestone?.number ?? 'no-milestone'}-cards`}>
+                  <tr key={`${project?.id ?? 'no-epic'}-cards`}>
                     {cols.map((status) => {
-                      const milestoneNumber = milestone?.number ?? null;
-                      const items = cellIssues(milestoneNumber, status);
+                      const projectId = project?.id ?? null;
+                      const items = cellIssues(projectId, status);
                       return (
                         <td
                           key={kanbanColKey(status)}
                           className="border border-gray-200 align-top p-2 bg-white"
                           style={{ width: colK(status), minWidth: colK(status) }}
                         >
-                          <Droppable droppableId={kanbanCellId(status, milestoneNumber)} type="CARD">
+                          <Droppable droppableId={kanbanCellId(status, projectId)} type="CARD">
                             {(provided, snapshot) => (
                               <div
                                 ref={provided.innerRef}
@@ -179,7 +167,7 @@ export default function KanbanView() {
                                 ))}
                                 {provided.placeholder}
                                 <button
-                                  onClick={() => setCreateCell({ milestoneNumber, statusLabel: status })}
+                                  onClick={() => setCreateCell({ projectId, statusLabel: status })}
                                   className="mt-auto w-full text-xs text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg py-1.5 border border-dashed border-gray-200 hover:border-green-300 transition-colors flex items-center justify-center gap-1"
                                 >
                                   <span className="text-sm font-medium leading-none">+</span>
@@ -201,7 +189,7 @@ export default function KanbanView() {
 
       {createCell && (
         <CreateIssueModal
-          defaultMilestoneNumber={createCell.milestoneNumber ?? undefined}
+          defaultMilestoneNumber={kanbanMilestoneNumber ?? undefined}
           defaultStatusLabel={createCell.statusLabel}
           onClose={() => setCreateCell(null)}
         />

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -186,11 +186,27 @@ export default function StoryMap() {
     const { draggableId, source, destination } = result;
 
     if (source.droppableId === 'columns') {
-      if (source.index !== destination.index) reorderProjects(source.index, destination.index);
+      if (source.index !== destination.index) {
+        const from = cols[source.index];
+        const to = cols[destination.index];
+        if (from && to) {
+          const fi = layout.epicOrder.indexOf(from.number);
+          const ti = layout.epicOrder.indexOf(to.number);
+          if (fi !== -1 && ti !== -1) reorderProjects(fi, ti);
+        }
+      }
       return;
     }
     if (source.droppableId === 'rows') {
-      if (source.index !== destination.index) reorderMilestones(source.index, destination.index);
+      if (source.index !== destination.index) {
+        const from = orderedMilestones[source.index];
+        const to = orderedMilestones[destination.index];
+        if (from && to) {
+          const fi = (layout.milestoneOrder ?? []).indexOf(from.number);
+          const ti = (layout.milestoneOrder ?? []).indexOf(to.number);
+          if (fi !== -1 && ti !== -1) reorderMilestones(fi, ti);
+        }
+      }
       return;
     }
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { Octokit } from '@octokit/rest';
-import type { GitHubIssue, GitHubMilestone, GitHubProject, ProjectV2StatusField, StoryMapLayout } from '../types';
+import type { GitHubIssue, GitHubMilestone, GitHubProject, StoryMapLayout } from '../types';
 import { loadLayout, saveLayout } from '../lib/firebase';
 
 interface AppState {
@@ -19,14 +19,8 @@ interface AppState {
   projectIssues: Record<string, number[]>; // project node_id → issue numbers
   /** Column resize widths in pixels, keyed by column identifier (project ID or status string). */
   columnWidths: Record<string, number>;
-  /** Selected GitHub Project for native Kanban mode (null = label mode). */
-  kanbanProjectId: string | null;
-  /** Status single-select field for the selected project. */
-  kanbanStatusField: ProjectV2StatusField | null;
-  /** issue number → status option name within the selected project. */
-  kanbanIssueStatuses: Record<number, string>;
-  /** issue number → ProjectV2Item node ID within the selected project. */
-  kanbanItemIds: Record<number, string>;
+  /** Selected milestone number for the Kanban wave filter (null = all waves). */
+  kanbanMilestoneNumber: number | null;
 
   setCredentials: (token: string, owner: string, repo: string) => void;
   fetchIssues: () => Promise<void>;
@@ -80,15 +74,15 @@ interface AppState {
   ) => Promise<void>;
   /** Persist a resized column width to state and localStorage. */
   setColumnWidth: (key: string, width: number) => void;
-  /** Select a GitHub Project for native Kanban mode (null clears selection). */
-  setKanbanProject: (projectId: string | null) => Promise<void>;
-  /** Move an issue in project-native Kanban (updates ProjectV2 field value + milestone). */
-  moveIssueInKanbanNative: (
+  /** Set the wave/milestone filter for the Kanban board. */
+  setKanbanMilestone: (milestoneNumber: number | null) => void;
+  /** Move an issue in Kanban: updates status label and/or project membership. */
+  moveIssueInKanbanByProject: (
     issueNumber: number,
     fromStatus: string | null,
     toStatus: string | null,
-    fromMilestoneNumber: number | null,
-    toMilestoneNumber: number | null,
+    fromProjectId: string | null,
+    toProjectId: string | null,
   ) => Promise<void>;
 }
 
@@ -142,23 +136,20 @@ export const useAppStore = create<AppState>((set, get) => ({
   projects: [],
   projectIssues: {},
   columnWidths: JSON.parse(localStorage.getItem('gh_column_widths') ?? '{}') as Record<string, number>,
-  kanbanProjectId: null,
-  kanbanStatusField: null,
-  kanbanIssueStatuses: {},
-  kanbanItemIds: {},
+  kanbanMilestoneNumber: null,
 
   setCredentials: (token, owner, repo) => {
     localStorage.setItem('gh_token', token);
     localStorage.setItem('gh_owner', owner);
     localStorage.setItem('gh_repo', repo);
-    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanProjectId: null, kanbanStatusField: null, kanbanIssueStatuses: {}, kanbanItemIds: {} });
+    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null });
   },
 
   reset: () => {
     localStorage.removeItem('gh_token');
     localStorage.removeItem('gh_owner');
     localStorage.removeItem('gh_repo');
-    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanProjectId: null, kanbanStatusField: null, kanbanIssueStatuses: {}, kanbanItemIds: {} });
+    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null });
   },
 
   setView: (view) => set({ view }),
@@ -837,128 +828,83 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ columnWidths: newWidths });
   },
 
-  setKanbanProject: async (projectId) => {
-    if (!projectId) {
-      set({ kanbanProjectId: null, kanbanStatusField: null, kanbanIssueStatuses: {}, kanbanItemIds: {} });
-      return;
-    }
-    const { token } = get();
-    set({ kanbanProjectId: projectId, loading: true });
-    try {
-      type FieldNode = { id?: string; name?: string; options?: { id: string; name: string; color: string }[] };
-      type ItemNode = {
-        id: string;
-        content: { number: number } | null;
-        fieldValues: { nodes: Array<{ field?: { name: string }; optionId?: string; name?: string }> };
-      };
-      const data = await gql<{
-        node: { fields: { nodes: FieldNode[] }; items: { nodes: ItemNode[] } } | null;
-      }>(token, `
-        query($projectId: ID!) {
-          node(id: $projectId) {
-            ... on ProjectV2 {
-              fields(first: 20) {
-                nodes {
-                  ... on ProjectV2SingleSelectField {
-                    id name
-                    options { id name color }
-                  }
-                }
-              }
-              items(first: 100) {
-                nodes {
-                  id
-                  content { ... on Issue { number } }
-                  fieldValues(first: 20) {
-                    nodes {
-                      ... on ProjectV2ItemFieldSingleSelectValue {
-                        field { ... on ProjectV2SingleSelectField { name } }
-                        optionId
-                        name
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      `, { projectId });
+  setKanbanMilestone: (milestoneNumber) => set({ kanbanMilestoneNumber: milestoneNumber }),
 
-      const statusField = (data.node?.fields.nodes ?? []).find(
-        (f): f is { id: string; name: string; options: { id: string; name: string; color: string }[] } =>
-          !!f.id && f.name === 'Status' && Array.isArray(f.options),
-      ) ?? null;
-
-      const issueStatuses: Record<number, string> = {};
-      const itemIds: Record<number, string> = {};
-      for (const item of data.node?.items.nodes ?? []) {
-        const num = item.content?.number;
-        if (!num) continue;
-        itemIds[num] = item.id;
-        const sv = item.fieldValues.nodes.find(
-          (fv): fv is { field: { name: string }; optionId: string; name: string } =>
-            !!fv.field && fv.field.name === 'Status' && !!fv.name,
-        );
-        if (sv) issueStatuses[num] = sv.name;
-      }
-
-      set({ kanbanStatusField: statusField, kanbanIssueStatuses: issueStatuses, kanbanItemIds: itemIds, loading: false });
-    } catch (err) {
-      set({ loading: false, kanbanProjectId: null });
-      throw err;
-    }
-  },
-
-  moveIssueInKanbanNative: async (issueNumber, _fromStatus, toStatus, fromMilestoneNumber, toMilestoneNumber) => {
-    const { token, owner, repo, kanbanProjectId, kanbanStatusField, kanbanItemIds, kanbanIssueStatuses, issues, milestones } = get();
-    if (!kanbanProjectId || !kanbanStatusField) return;
+  moveIssueInKanbanByProject: async (issueNumber, fromStatus, toStatus, fromProjectId, toProjectId) => {
+    const { token, owner, repo, issues, projectIssues } = get();
     const issue = issues.find((i) => i.number === issueNumber);
     if (!issue) return;
 
-    const itemId = kanbanItemIds[issueNumber];
-    const option = toStatus ? kanbanStatusField.options.find((o) => o.name === toStatus) : null;
-    const newMilestone = toMilestoneNumber === null
-      ? null
-      : milestones.find((m) => m.number === toMilestoneNumber) ?? null;
-
-    const snapStatuses = kanbanIssueStatuses;
     const snapIssues = issues;
+    const snapProjectIssues = projectIssues;
+
+    const baseLabels = issue.labels.filter((l) => !l.name.startsWith('s_'));
+    const newLabels = toStatus
+      ? [...baseLabels, { id: 0, name: `s_${toStatus}`, color: '0e8a16' }]
+      : baseLabels;
+
+    let updatedProjectIssues = { ...projectIssues };
+    if (fromProjectId !== toProjectId) {
+      if (fromProjectId) {
+        updatedProjectIssues = {
+          ...updatedProjectIssues,
+          [fromProjectId]: (updatedProjectIssues[fromProjectId] ?? []).filter((n) => n !== issueNumber),
+        };
+      }
+      if (toProjectId) {
+        updatedProjectIssues = {
+          ...updatedProjectIssues,
+          [toProjectId]: [issueNumber, ...(updatedProjectIssues[toProjectId] ?? [])],
+        };
+      }
+    }
 
     set({
-      kanbanIssueStatuses: toStatus
-        ? { ...kanbanIssueStatuses, [issueNumber]: toStatus }
-        : Object.fromEntries(Object.entries(kanbanIssueStatuses).filter(([k]) => Number(k) !== issueNumber)),
-      issues: issues.map((i) => i.number === issueNumber ? { ...i, milestone: newMilestone } : i),
+      issues: issues.map((i) => i.number === issueNumber ? { ...i, labels: newLabels } : i),
+      projectIssues: updatedProjectIssues,
     });
 
     try {
-      if (itemId) {
-        if (option) {
-          await gql(token, `
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $projectId itemId: $itemId fieldId: $fieldId
-                value: { singleSelectOptionId: $optionId }
-              }) { projectV2Item { id } }
+      const octokit = new Octokit({ auth: token });
+      if (fromStatus !== toStatus) {
+        if (toStatus) await ensureLabel(octokit, owner, repo, `s_${toStatus}`, '0e8a16');
+        await octokit.rest.issues.setLabels({
+          owner, repo, issue_number: issueNumber,
+          labels: newLabels.map((l) => l.name),
+        });
+      }
+      if (fromProjectId !== toProjectId) {
+        if (fromProjectId) {
+          const data = await gql<{
+            node: { items: { nodes: Array<{ id: string; content: { id: string } | null }> } } | null;
+          }>(token, `
+            query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100) { nodes { id content { ... on Issue { id } } } }
+                }
+              }
             }
-          `, { projectId: kanbanProjectId, itemId, fieldId: kanbanStatusField.id, optionId: option.id });
-        } else {
+          `, { projectId: fromProjectId });
+          const item = data.node?.items.nodes.find((n) => n.content?.id === issue.node_id);
+          if (item) {
+            await gql(token, `
+              mutation($projectId: ID!, $itemId: ID!) {
+                deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) { deletedItemId }
+              }
+            `, { projectId: fromProjectId, itemId: item.id });
+          }
+        }
+        if (toProjectId) {
           await gql(token, `
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
-              clearProjectV2ItemFieldValue(input: {
-                projectId: $projectId itemId: $itemId fieldId: $fieldId
-              }) { projectV2Item { id } }
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } }
             }
-          `, { projectId: kanbanProjectId, itemId, fieldId: kanbanStatusField.id });
+          `, { projectId: toProjectId, contentId: issue.node_id });
         }
       }
-      if (fromMilestoneNumber !== toMilestoneNumber) {
-        const octokit = new Octokit({ auth: token });
-        await octokit.rest.issues.update({ owner, repo, issue_number: issueNumber, milestone: toMilestoneNumber });
-      }
     } catch (err) {
-      set({ kanbanIssueStatuses: snapStatuses, issues: snapIssues });
+      set({ issues: snapIssues, projectIssues: snapProjectIssues });
       throw err;
     }
   },

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -26,9 +26,11 @@ interface AppState {
   /** issue number → status option name (from whichever project the issue belongs to). */
   kanbanIssueStatuses: Record<number, string>;
   /** projectId → { fieldId, options } for the Status single-select field. */
-  kanbanProjectStatusFields: Record<string, { fieldId: string; options: { id: string; name: string }[] }>;
+  kanbanProjectStatusFields: Record<string, { fieldId: string; options: { id: string; name: string; color?: string }[] }>;
   /** issue number → ProjectV2Item node ID (needed to update field values). */
   kanbanItemIds: Record<number, string>;
+  /** status option name → GitHub color enum string (e.g. "YELLOW", "GREEN"). */
+  kanbanStatusColors: Record<string, string>;
 
   setCredentials: (token: string, owner: string, repo: string) => void;
   fetchIssues: () => Promise<void>;
@@ -151,19 +153,20 @@ export const useAppStore = create<AppState>((set, get) => ({
   kanbanIssueStatuses: {},
   kanbanProjectStatusFields: {},
   kanbanItemIds: {},
+  kanbanStatusColors: {},
 
   setCredentials: (token, owner, repo) => {
     localStorage.setItem('gh_token', token);
     localStorage.setItem('gh_owner', owner);
     localStorage.setItem('gh_repo', repo);
-    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {} });
+    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {} });
   },
 
   reset: () => {
     localStorage.removeItem('gh_token');
     localStorage.removeItem('gh_owner');
     localStorage.removeItem('gh_repo');
-    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {} });
+    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {} });
   },
 
   setView: (view) => set({ view }),
@@ -850,7 +853,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const openProjects = projects.filter((p) => !p.closed);
     if (openProjects.length === 0) return;
 
-    type FieldNode = { id?: string; name?: string; options?: { id: string; name: string }[] };
+    type FieldNode = { id?: string; name?: string; options?: { id: string; name: string; color?: string }[] };
     type ItemNode = {
       id: string;
       content: { number: number } | null;
@@ -866,7 +869,7 @@ export const useAppStore = create<AppState>((set, get) => ({
               ... on ProjectV2 {
                 fields(first: 20) {
                   nodes {
-                    ... on ProjectV2SingleSelectField { id name options { id name } }
+                    ... on ProjectV2SingleSelectField { id name options { id name color } }
                   }
                 }
                 items(first: 100) {
@@ -890,10 +893,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       ),
     );
 
-    const statusFields: Record<string, { fieldId: string; options: { id: string; name: string }[] }> = {};
+    const statusFields: Record<string, { fieldId: string; options: { id: string; name: string; color?: string }[] }> = {};
     const issueStatuses: Record<number, string> = {};
     const itemIds: Record<number, string> = {};
     const columnOrder: string[] = [];
+    const statusColors: Record<string, string> = {};
     const seen = new Set<string>();
 
     for (const result of results) {
@@ -903,13 +907,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (!node) continue;
 
       const statusField = node.fields.nodes.find(
-        (f): f is { id: string; name: string; options: { id: string; name: string }[] } =>
+        (f): f is { id: string; name: string; options: { id: string; name: string; color?: string }[] } =>
           !!f.id && f.name === 'Status' && Array.isArray(f.options),
       );
       if (statusField) {
         statusFields[projectId] = { fieldId: statusField.id, options: statusField.options };
         for (const opt of statusField.options) {
           if (!seen.has(opt.name)) { seen.add(opt.name); columnOrder.push(opt.name); }
+          if (opt.color && !statusColors[opt.name]) statusColors[opt.name] = opt.color;
         }
       }
 
@@ -929,6 +934,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       kanbanIssueStatuses: issueStatuses,
       kanbanProjectStatusFields: statusFields,
       kanbanItemIds: itemIds,
+      kanbanStatusColors: statusColors,
     });
   },
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { Octokit } from '@octokit/rest';
-import type { GitHubIssue, GitHubMilestone, GitHubProject, StoryMapLayout } from '../types';
+import type { GitHubIssue, GitHubMilestone, GitHubProject, ProjectV2StatusField, StoryMapLayout } from '../types';
 import { loadLayout, saveLayout } from '../lib/firebase';
 
 interface AppState {
@@ -19,6 +19,14 @@ interface AppState {
   projectIssues: Record<string, number[]>; // project node_id → issue numbers
   /** Column resize widths in pixels, keyed by column identifier (project ID or status string). */
   columnWidths: Record<string, number>;
+  /** Selected GitHub Project for native Kanban mode (null = label mode). */
+  kanbanProjectId: string | null;
+  /** Status single-select field for the selected project. */
+  kanbanStatusField: ProjectV2StatusField | null;
+  /** issue number → status option name within the selected project. */
+  kanbanIssueStatuses: Record<number, string>;
+  /** issue number → ProjectV2Item node ID within the selected project. */
+  kanbanItemIds: Record<number, string>;
 
   setCredentials: (token: string, owner: string, repo: string) => void;
   fetchIssues: () => Promise<void>;
@@ -72,6 +80,16 @@ interface AppState {
   ) => Promise<void>;
   /** Persist a resized column width to state and localStorage. */
   setColumnWidth: (key: string, width: number) => void;
+  /** Select a GitHub Project for native Kanban mode (null clears selection). */
+  setKanbanProject: (projectId: string | null) => Promise<void>;
+  /** Move an issue in project-native Kanban (updates ProjectV2 field value + milestone). */
+  moveIssueInKanbanNative: (
+    issueNumber: number,
+    fromStatus: string | null,
+    toStatus: string | null,
+    fromMilestoneNumber: number | null,
+    toMilestoneNumber: number | null,
+  ) => Promise<void>;
 }
 
 const emptyLayout: StoryMapLayout = { epicOrder: [], milestoneOrder: [], storyOrder: { backlog: [] } };
@@ -124,19 +142,23 @@ export const useAppStore = create<AppState>((set, get) => ({
   projects: [],
   projectIssues: {},
   columnWidths: JSON.parse(localStorage.getItem('gh_column_widths') ?? '{}') as Record<string, number>,
+  kanbanProjectId: null,
+  kanbanStatusField: null,
+  kanbanIssueStatuses: {},
+  kanbanItemIds: {},
 
   setCredentials: (token, owner, repo) => {
     localStorage.setItem('gh_token', token);
     localStorage.setItem('gh_owner', owner);
     localStorage.setItem('gh_repo', repo);
-    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {} });
+    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanProjectId: null, kanbanStatusField: null, kanbanIssueStatuses: {}, kanbanItemIds: {} });
   },
 
   reset: () => {
     localStorage.removeItem('gh_token');
     localStorage.removeItem('gh_owner');
     localStorage.removeItem('gh_repo');
-    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {} });
+    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanProjectId: null, kanbanStatusField: null, kanbanIssueStatuses: {}, kanbanItemIds: {} });
   },
 
   setView: (view) => set({ view }),
@@ -813,5 +835,131 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newWidths = { ...get().columnWidths, [key]: width };
     localStorage.setItem('gh_column_widths', JSON.stringify(newWidths));
     set({ columnWidths: newWidths });
+  },
+
+  setKanbanProject: async (projectId) => {
+    if (!projectId) {
+      set({ kanbanProjectId: null, kanbanStatusField: null, kanbanIssueStatuses: {}, kanbanItemIds: {} });
+      return;
+    }
+    const { token } = get();
+    set({ kanbanProjectId: projectId, loading: true });
+    try {
+      type FieldNode = { id?: string; name?: string; options?: { id: string; name: string; color: string }[] };
+      type ItemNode = {
+        id: string;
+        content: { number: number } | null;
+        fieldValues: { nodes: Array<{ field?: { name: string }; optionId?: string; name?: string }> };
+      };
+      const data = await gql<{
+        node: { fields: { nodes: FieldNode[] }; items: { nodes: ItemNode[] } } | null;
+      }>(token, `
+        query($projectId: ID!) {
+          node(id: $projectId) {
+            ... on ProjectV2 {
+              fields(first: 20) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    id name
+                    options { id name color }
+                  }
+                }
+              }
+              items(first: 100) {
+                nodes {
+                  id
+                  content { ... on Issue { number } }
+                  fieldValues(first: 20) {
+                    nodes {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        field { ... on ProjectV2SingleSelectField { name } }
+                        optionId
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `, { projectId });
+
+      const statusField = (data.node?.fields.nodes ?? []).find(
+        (f): f is { id: string; name: string; options: { id: string; name: string; color: string }[] } =>
+          !!f.id && f.name === 'Status' && Array.isArray(f.options),
+      ) ?? null;
+
+      const issueStatuses: Record<number, string> = {};
+      const itemIds: Record<number, string> = {};
+      for (const item of data.node?.items.nodes ?? []) {
+        const num = item.content?.number;
+        if (!num) continue;
+        itemIds[num] = item.id;
+        const sv = item.fieldValues.nodes.find(
+          (fv): fv is { field: { name: string }; optionId: string; name: string } =>
+            !!fv.field && fv.field.name === 'Status' && !!fv.name,
+        );
+        if (sv) issueStatuses[num] = sv.name;
+      }
+
+      set({ kanbanStatusField: statusField, kanbanIssueStatuses: issueStatuses, kanbanItemIds: itemIds, loading: false });
+    } catch (err) {
+      set({ loading: false, kanbanProjectId: null });
+      throw err;
+    }
+  },
+
+  moveIssueInKanbanNative: async (issueNumber, _fromStatus, toStatus, fromMilestoneNumber, toMilestoneNumber) => {
+    const { token, owner, repo, kanbanProjectId, kanbanStatusField, kanbanItemIds, kanbanIssueStatuses, issues, milestones } = get();
+    if (!kanbanProjectId || !kanbanStatusField) return;
+    const issue = issues.find((i) => i.number === issueNumber);
+    if (!issue) return;
+
+    const itemId = kanbanItemIds[issueNumber];
+    const option = toStatus ? kanbanStatusField.options.find((o) => o.name === toStatus) : null;
+    const newMilestone = toMilestoneNumber === null
+      ? null
+      : milestones.find((m) => m.number === toMilestoneNumber) ?? null;
+
+    const snapStatuses = kanbanIssueStatuses;
+    const snapIssues = issues;
+
+    set({
+      kanbanIssueStatuses: toStatus
+        ? { ...kanbanIssueStatuses, [issueNumber]: toStatus }
+        : Object.fromEntries(Object.entries(kanbanIssueStatuses).filter(([k]) => Number(k) !== issueNumber)),
+      issues: issues.map((i) => i.number === issueNumber ? { ...i, milestone: newMilestone } : i),
+    });
+
+    try {
+      if (itemId) {
+        if (option) {
+          await gql(token, `
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId itemId: $itemId fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) { projectV2Item { id } }
+            }
+          `, { projectId: kanbanProjectId, itemId, fieldId: kanbanStatusField.id, optionId: option.id });
+        } else {
+          await gql(token, `
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+              clearProjectV2ItemFieldValue(input: {
+                projectId: $projectId itemId: $itemId fieldId: $fieldId
+              }) { projectV2Item { id } }
+            }
+          `, { projectId: kanbanProjectId, itemId, fieldId: kanbanStatusField.id });
+        }
+      }
+      if (fromMilestoneNumber !== toMilestoneNumber) {
+        const octokit = new Octokit({ auth: token });
+        await octokit.rest.issues.update({ owner, repo, issue_number: issueNumber, milestone: toMilestoneNumber });
+      }
+    } catch (err) {
+      set({ kanbanIssueStatuses: snapStatuses, issues: snapIssues });
+      throw err;
+    }
   },
 }));

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -21,6 +21,14 @@ interface AppState {
   columnWidths: Record<string, number>;
   /** Selected milestone number for the Kanban wave filter (null = all waves). */
   kanbanMilestoneNumber: number | null;
+  /** Ordered union of status option names across all open projects (Kanban columns). */
+  kanbanStatusColumns: string[];
+  /** issue number → status option name (from whichever project the issue belongs to). */
+  kanbanIssueStatuses: Record<number, string>;
+  /** projectId → { fieldId, options } for the Status single-select field. */
+  kanbanProjectStatusFields: Record<string, { fieldId: string; options: { id: string; name: string }[] }>;
+  /** issue number → ProjectV2Item node ID (needed to update field values). */
+  kanbanItemIds: Record<number, string>;
 
   setCredentials: (token: string, owner: string, repo: string) => void;
   fetchIssues: () => Promise<void>;
@@ -76,7 +84,9 @@ interface AppState {
   setColumnWidth: (key: string, width: number) => void;
   /** Set the wave/milestone filter for the Kanban board. */
   setKanbanMilestone: (milestoneNumber: number | null) => void;
-  /** Move an issue in Kanban: updates status label and/or project membership. */
+  /** Fetch native status field options + item statuses for all open projects. */
+  fetchAllProjectStatuses: () => Promise<void>;
+  /** Move an issue in Kanban: updates native status field and/or project membership. */
   moveIssueInKanbanByProject: (
     issueNumber: number,
     fromStatus: string | null,
@@ -137,19 +147,23 @@ export const useAppStore = create<AppState>((set, get) => ({
   projectIssues: {},
   columnWidths: JSON.parse(localStorage.getItem('gh_column_widths') ?? '{}') as Record<string, number>,
   kanbanMilestoneNumber: null,
+  kanbanStatusColumns: [],
+  kanbanIssueStatuses: {},
+  kanbanProjectStatusFields: {},
+  kanbanItemIds: {},
 
   setCredentials: (token, owner, repo) => {
     localStorage.setItem('gh_token', token);
     localStorage.setItem('gh_owner', owner);
     localStorage.setItem('gh_repo', repo);
-    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null });
+    set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {} });
   },
 
   reset: () => {
     localStorage.removeItem('gh_token');
     localStorage.removeItem('gh_owner');
     localStorage.removeItem('gh_repo');
-    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null });
+    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {} });
   },
 
   setView: (view) => set({ view }),
@@ -830,18 +844,101 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setKanbanMilestone: (milestoneNumber) => set({ kanbanMilestoneNumber: milestoneNumber }),
 
+  fetchAllProjectStatuses: async () => {
+    const { token, projects } = get();
+    if (!token) return;
+    const openProjects = projects.filter((p) => !p.closed);
+    if (openProjects.length === 0) return;
+
+    type FieldNode = { id?: string; name?: string; options?: { id: string; name: string }[] };
+    type ItemNode = {
+      id: string;
+      content: { number: number } | null;
+      fieldValues: { nodes: Array<{ field?: { name: string }; name?: string }> };
+    };
+    type ProjectData = { node: { fields: { nodes: FieldNode[] }; items: { nodes: ItemNode[] } } | null };
+
+    const results = await Promise.all(
+      openProjects.map((p) =>
+        gql<ProjectData>(token, `
+          query($projectId: ID!) {
+            node(id: $projectId) {
+              ... on ProjectV2 {
+                fields(first: 20) {
+                  nodes {
+                    ... on ProjectV2SingleSelectField { id name options { id name } }
+                  }
+                }
+                items(first: 100) {
+                  nodes {
+                    id
+                    content { ... on Issue { number } }
+                    fieldValues(first: 10) {
+                      nodes {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          field { ... on ProjectV2SingleSelectField { name } }
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `, { projectId: p.id }).then((d) => ({ projectId: p.id, data: d })).catch(() => null),
+      ),
+    );
+
+    const statusFields: Record<string, { fieldId: string; options: { id: string; name: string }[] }> = {};
+    const issueStatuses: Record<number, string> = {};
+    const itemIds: Record<number, string> = {};
+    const columnOrder: string[] = [];
+    const seen = new Set<string>();
+
+    for (const result of results) {
+      if (!result) continue;
+      const { projectId, data } = result;
+      const node = data.node;
+      if (!node) continue;
+
+      const statusField = node.fields.nodes.find(
+        (f): f is { id: string; name: string; options: { id: string; name: string }[] } =>
+          !!f.id && f.name === 'Status' && Array.isArray(f.options),
+      );
+      if (statusField) {
+        statusFields[projectId] = { fieldId: statusField.id, options: statusField.options };
+        for (const opt of statusField.options) {
+          if (!seen.has(opt.name)) { seen.add(opt.name); columnOrder.push(opt.name); }
+        }
+      }
+
+      for (const item of node.items.nodes) {
+        const num = item.content?.number;
+        if (!num) continue;
+        itemIds[num] = item.id;
+        const sv = item.fieldValues.nodes.find(
+          (fv): fv is { field: { name: string }; name: string } => !!fv.field && fv.field.name === 'Status' && !!fv.name,
+        );
+        if (sv) issueStatuses[num] = sv.name;
+      }
+    }
+
+    set({
+      kanbanStatusColumns: columnOrder,
+      kanbanIssueStatuses: issueStatuses,
+      kanbanProjectStatusFields: statusFields,
+      kanbanItemIds: itemIds,
+    });
+  },
+
   moveIssueInKanbanByProject: async (issueNumber, fromStatus, toStatus, fromProjectId, toProjectId) => {
-    const { token, owner, repo, issues, projectIssues } = get();
+    const { token, issues, projectIssues, kanbanIssueStatuses, kanbanProjectStatusFields, kanbanItemIds } = get();
     const issue = issues.find((i) => i.number === issueNumber);
     if (!issue) return;
 
-    const snapIssues = issues;
     const snapProjectIssues = projectIssues;
-
-    const baseLabels = issue.labels.filter((l) => !l.name.startsWith('s_'));
-    const newLabels = toStatus
-      ? [...baseLabels, { id: 0, name: `s_${toStatus}`, color: '0e8a16' }]
-      : baseLabels;
+    const snapStatuses = kanbanIssueStatuses;
 
     let updatedProjectIssues = { ...projectIssues };
     if (fromProjectId !== toProjectId) {
@@ -859,20 +956,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     }
 
-    set({
-      issues: issues.map((i) => i.number === issueNumber ? { ...i, labels: newLabels } : i),
-      projectIssues: updatedProjectIssues,
-    });
+    const newStatuses = toStatus
+      ? { ...kanbanIssueStatuses, [issueNumber]: toStatus }
+      : Object.fromEntries(Object.entries(kanbanIssueStatuses).filter(([k]) => Number(k) !== issueNumber));
+
+    set({ projectIssues: updatedProjectIssues, kanbanIssueStatuses: newStatuses });
 
     try {
-      const octokit = new Octokit({ auth: token });
-      if (fromStatus !== toStatus) {
-        if (toStatus) await ensureLabel(octokit, owner, repo, `s_${toStatus}`, '0e8a16');
-        await octokit.rest.issues.setLabels({
-          owner, repo, issue_number: issueNumber,
-          labels: newLabels.map((l) => l.name),
-        });
-      }
       if (fromProjectId !== toProjectId) {
         if (fromProjectId) {
           const data = await gql<{
@@ -896,15 +986,58 @@ export const useAppStore = create<AppState>((set, get) => ({
           }
         }
         if (toProjectId) {
-          await gql(token, `
+          const addResult = await gql<{ addProjectV2ItemById: { item: { id: string } } }>(token, `
             mutation($projectId: ID!, $contentId: ID!) {
               addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } }
             }
           `, { projectId: toProjectId, contentId: issue.node_id });
+          const newItemId = addResult.addProjectV2ItemById.item.id;
+          set({ kanbanItemIds: { ...get().kanbanItemIds, [issueNumber]: newItemId } });
+
+          if (toStatus) {
+            const field = kanbanProjectStatusFields[toProjectId];
+            const option = field?.options.find((o) => o.name === toStatus);
+            if (field && option) {
+              await gql(token, `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId itemId: $itemId fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }
+              `, { projectId: toProjectId, itemId: newItemId, fieldId: field.fieldId, optionId: option.id });
+            }
+          }
+        }
+      } else if (fromStatus !== toStatus && toProjectId) {
+        const itemId = kanbanItemIds[issueNumber];
+        const field = kanbanProjectStatusFields[toProjectId];
+        if (itemId && field) {
+          if (toStatus) {
+            const option = field.options.find((o) => o.name === toStatus);
+            if (option) {
+              await gql(token, `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId itemId: $itemId fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }
+              `, { projectId: toProjectId, itemId, fieldId: field.fieldId, optionId: option.id });
+            }
+          } else {
+            await gql(token, `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+                clearProjectV2ItemFieldValue(input: {
+                  projectId: $projectId itemId: $itemId fieldId: $fieldId
+                }) { projectV2Item { id } }
+              }
+            `, { projectId: toProjectId, itemId, fieldId: field.fieldId });
+          }
         }
       }
     } catch (err) {
-      set({ issues: snapIssues, projectIssues: snapProjectIssues });
+      set({ projectIssues: snapProjectIssues, kanbanIssueStatuses: snapStatuses });
       throw err;
     }
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,14 +45,3 @@ export interface GitHubProject {
   closed: boolean;
 }
 
-export interface ProjectV2StatusOption {
-  id: string;
-  name: string;
-  color: string;
-}
-
-export interface ProjectV2StatusField {
-  id: string;
-  name: string;
-  options: ProjectV2StatusOption[];
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,3 +44,15 @@ export interface GitHubProject {
   url: string;
   closed: boolean;
 }
+
+export interface ProjectV2StatusOption {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface ProjectV2StatusField {
+  id: string;
+  name: string;
+  options: ProjectV2StatusOption[];
+}


### PR DESCRIPTION
## Summary
- Adds a **Project selector** dropdown at the top of the Kanban tab; selecting a project switches the board to native-mode where columns are the project's own Status field options (instead of `s_*` labels).
- In project-native mode, issue placement and drag-and-drop update the `ProjectV2ItemFieldValue` via GraphQL, leaving repository labels untouched.
- Falls back transparently to existing label-based mode when no project is selected (dropdown shows "Label-based (s_ labels)").

## Implementation notes
- New store state: `kanbanProjectId`, `kanbanStatusField`, `kanbanIssueStatuses`, `kanbanItemIds` — loaded by `setKanbanProject()` which queries the project's `fields` and `items.fieldValues` in one GraphQL call.
- New action `moveIssueInKanbanNative` handles both the `updateProjectV2ItemFieldValue` mutation and milestone REST updates, with optimistic revert on error.
- In project mode the visible issue set is filtered to issues that belong to the selected project (`projectIssues[kanbanProjectId]`), so the board accurately reflects the project's scope.
- If a project has no Status single-select field, an amber notice is shown and all issues fall into the "No Status" column.

## Test plan
- [ ] Open Kanban tab — Project dropdown is visible, default is "Label-based".
- [ ] Select a GitHub Project → board columns change to the project's Status field options.
- [ ] Only issues inside the selected project appear on the board.
- [ ] Drag an issue to a different status column → the project item's Status field is updated on GitHub.
- [ ] Drag an issue to a different wave row → the issue's milestone is updated via REST.
- [ ] Switch back to "Label-based" → columns revert to `s_*` labels and all issues reappear.
- [ ] Select a project with no Status field → amber warning shown; issues appear in No Status column.
- [ ] Grid/Kanban toggle continues to work normally.

Closes #40