### PR TITLE
Closed issues for examples

### DIFF
--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -3,7 +3,14 @@ import { useAppStore } from '../store/appStore';
 import { loadGeminiSettings, saveGeminiSettings, testGeminiConnection, DEFAULT_GEMINI_MODEL } from '../lib/gemini';
 import { loadAnthropicSettings, saveAnthropicSettings } from '../lib/anthropic';
 
+type Tab = 'general' | 'describing' | 'coding';
 type LedState = 'idle' | 'testing' | 'success' | 'error';
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'general', label: 'General' },
+  { key: 'describing', label: 'Describing' },
+  { key: 'coding', label: 'Coding' },
+];
 
 function Led({ state, onClick }: { state: LedState; onClick: () => void }) {
   const colors: Record<LedState, string> = {
@@ -16,31 +23,63 @@ function Led({ state, onClick }: { state: LedState; onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      title={state === 'idle' ? 'Click to test connection' : state === 'testing' ? 'Testing…' : state === 'success' ? 'Connected' : 'Connection failed — click to retry'}
+      title={
+        state === 'idle'
+          ? 'Click to test connection'
+          : state === 'testing'
+          ? 'Testing…'
+          : state === 'success'
+          ? 'Connected'
+          : 'Connection failed — click to retry'
+      }
       className="flex items-center gap-1.5 group"
     >
       <span className={`w-2.5 h-2.5 rounded-full shrink-0 transition-colors ${colors[state]}`} />
       <span className="text-xs text-gray-400 group-hover:text-gray-600 transition-colors">
-        {state === 'idle' ? 'Test' : state === 'testing' ? 'Testing…' : state === 'success' ? 'Connected' : 'Failed'}
+        {state === 'idle'
+          ? 'Test'
+          : state === 'testing'
+          ? 'Testing…'
+          : state === 'success'
+          ? 'Connected'
+          : 'Failed'}
       </span>
     </button>
   );
 }
 
 export default function SettingsView() {
-  const { issues } = useAppStore();
-  const saved = loadGeminiSettings();
-  const savedAnthropic = loadAnthropicSettings();
+  const {
+    token,
+    owner,
+    repo,
+    issues,
+    setCredentials,
+    fetchIssues,
+    fetchLabels,
+    fetchProjects,
+    fetchMilestones,
+    fetchAllProjectStatuses,
+  } = useAppStore();
 
-  // Gemini
-  const [apiKey, setApiKey] = useState(saved.apiKey);
-  const [model, setModel] = useState(saved.model);
-  const [exampleNumbers, setExampleNumbers] = useState<number[]>(saved.exampleIssueNumbers);
-  const [extraInstructions, setExtraInstructions] = useState(saved.extraInstructions);
+  const [activeTab, setActiveTab] = useState<Tab>('general');
+
+  // General tab state
+  const [ghToken, setGhToken] = useState(token);
+  const [ghOwner, setGhOwner] = useState(owner);
+  const [ghRepo, setGhRepo] = useState(repo);
+
+  // Describing tab state
+  const savedGemini = loadGeminiSettings();
+  const [apiKey, setApiKey] = useState(savedGemini.apiKey);
+  const [model, setModel] = useState(savedGemini.model);
+  const [exampleNumbers, setExampleNumbers] = useState<number[]>(savedGemini.exampleIssueNumbers);
+  const [extraInstructions, setExtraInstructions] = useState(savedGemini.extraInstructions);
   const [search, setSearch] = useState('');
   const [ledState, setLedState] = useState<LedState>('idle');
 
-  // Anthropic
+  // Coding tab state
+  const savedAnthropic = loadAnthropicSettings();
   const [anthropicKey, setAnthropicKey] = useState(savedAnthropic.apiKey);
   const [agentId, setAgentId] = useState(savedAnthropic.agentId);
   const [envId, setEnvId] = useState(savedAnthropic.envId);
@@ -61,8 +100,20 @@ export default function SettingsView() {
   }
 
   function handleSave() {
-    saveGeminiSettings({ apiKey, model, exampleIssueNumbers: exampleNumbers, extraInstructions });
-    saveAnthropicSettings({ apiKey: anthropicKey, agentId, envId, vaultId });
+    if (activeTab === 'general') {
+      const credentialsChanged = ghToken !== token || ghOwner !== owner || ghRepo !== repo;
+      if (credentialsChanged) {
+        setCredentials(ghToken.trim(), ghOwner.trim(), ghRepo.trim());
+        fetchIssues();
+        fetchLabels();
+        fetchProjects().then(() => fetchAllProjectStatuses());
+        fetchMilestones();
+      }
+    } else if (activeTab === 'describing') {
+      saveGeminiSettings({ apiKey, model, exampleIssueNumbers: exampleNumbers, extraInstructions });
+    } else if (activeTab === 'coding') {
+      saveAnthropicSettings({ apiKey: anthropicKey, agentId, envId, vaultId });
+    }
     setSaved_(true);
     setTimeout(() => setSaved_(false), 2000);
   }
@@ -77,193 +128,288 @@ export default function SettingsView() {
 
   const filtered = issues
     .filter((i) => i.state === 'open')
-    .filter((i) =>
-      i.title.toLowerCase().includes(search.toLowerCase()) ||
-      String(i.number).includes(search),
+    .filter(
+      (i) =>
+        i.title.toLowerCase().includes(search.toLowerCase()) || String(i.number).includes(search),
     );
 
   return (
-    <div className="flex-1 overflow-y-auto bg-gray-50">
-      <div className="max-w-lg mx-auto py-8 px-4 space-y-6">
-        {/* Gemini API Key */}
-        <div>
-          <div className="flex items-center justify-between mb-1">
-            <label className="block text-sm font-medium text-gray-700">Gemini API Key</label>
-            <Led state={ledState} onClick={handleTest} />
-          </div>
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => { setApiKey(e.target.value); setLedState('idle'); }}
-            placeholder="AIza…"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          <p className="text-xs text-gray-400 mt-1">
-            Stored in localStorage only. Used to auto-generate issue descriptions via Gemini.
-          </p>
-        </div>
-
-        {/* Model */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Model</label>
-          <input
-            type="text"
-            value={model}
-            onChange={(e) => { setModel(e.target.value); setLedState('idle'); }}
-            placeholder={DEFAULT_GEMINI_MODEL}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
-          />
-        </div>
-
-        {/* Example Issues */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Example Issues{' '}
-            <span className="text-gray-400 font-normal">(up to 3 — sent as style references)</span>
-          </label>
-
-          {exampleNumbers.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mb-2">
-              {exampleNumbers.map((num) => {
-                const issue = issues.find((i) => i.number === num);
-                return (
-                  <span
-                    key={num}
-                    className="flex items-center gap-1 px-2 py-1 bg-blue-50 text-blue-700 text-xs rounded-full border border-blue-200"
-                  >
-                    #{num}{issue ? ` · ${issue.title.slice(0, 28)}…` : ''}
-                    <button
-                      onClick={() => toggleExample(num)}
-                      className="hover:text-red-500 leading-none ml-0.5"
-                    >
-                      ×
-                    </button>
-                  </span>
-                );
-              })}
-            </div>
-          )}
-
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search issues…"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
-          />
-
-          <ul className="border border-gray-200 rounded-lg divide-y divide-gray-100 max-h-44 overflow-y-auto bg-white">
-            {filtered.slice(0, 50).map((issue) => {
-              const selected = exampleNumbers.includes(issue.number);
-              const disabled = !selected && exampleNumbers.length >= 3;
-              return (
-                <li key={issue.number}>
-                  <button
-                    onClick={() => !disabled && toggleExample(issue.number)}
-                    disabled={disabled}
-                    className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 transition-colors ${
-                      selected
-                        ? 'bg-blue-50 text-blue-700'
-                        : disabled
-                        ? 'opacity-40 cursor-not-allowed text-gray-700'
-                        : 'hover:bg-gray-50 text-gray-700'
-                    }`}
-                  >
-                    <span className="text-gray-400 tabular-nums shrink-0 text-xs">#{issue.number}</span>
-                    <span className="truncate">{issue.title}</span>
-                    {selected && <span className="ml-auto text-blue-500 shrink-0 text-xs">✓</span>}
-                  </button>
-                </li>
-              );
-            })}
-            {filtered.length === 0 && (
-              <li className="px-3 py-3 text-sm text-gray-400">No issues found.</li>
-            )}
-          </ul>
-        </div>
-
-        {/* Additional Instructions */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Additional Instructions
-          </label>
-          <textarea
-            value={extraInstructions}
-            onChange={(e) => setExtraInstructions(e.target.value)}
-            rows={3}
-            placeholder="e.g. Always write in Portuguese. Keep acceptance criteria concise."
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-          />
-        </div>
-
-        {/* Divider */}
-        <div className="border-t border-gray-200 pt-6">
-          <div className="flex items-center gap-2 mb-4">
-            <span className="text-sm font-semibold text-gray-900">Code with AI</span>
-            <span className="text-xs bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full font-medium">beta</span>
-          </div>
-          <p className="text-xs text-gray-400 mb-4">
-            Triggers a Claude Managed Agent session to implement an issue — creating a branch, writing code, and opening a PR. Requires a pre-configured agent with GitHub MCP access.
-          </p>
-
-          <div className="space-y-3">
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Anthropic API Key</label>
-              <input
-                type="password"
-                value={anthropicKey}
-                onChange={(e) => setAnthropicKey(e.target.value)}
-                placeholder="sk-ant-…"
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Agent ID</label>
-              <input
-                type="text"
-                value={agentId}
-                onChange={(e) => setAgentId(e.target.value)}
-                placeholder="agent_…"
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Environment ID</label>
-              <input
-                type="text"
-                value={envId}
-                onChange={(e) => setEnvId(e.target.value)}
-                placeholder="env_…"
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Vault ID</label>
-              <input
-                type="text"
-                value={vaultId}
-                onChange={(e) => setVaultId(e.target.value)}
-                placeholder="vlt_…"
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
-              />
-              <p className="text-xs text-gray-400 mt-1">
-                The vault holds your GitHub OAuth token — the agent uses it automatically via GitHub MCP.
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex justify-end">
+    <div className="flex-1 overflow-hidden flex">
+      {/* Sidebar */}
+      <nav className="w-48 border-r border-gray-200 bg-white py-6 px-3 shrink-0 flex flex-col gap-1">
+        {TABS.map(({ key, label }) => (
           <button
-            onClick={handleSave}
-            className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-              saved_
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-900 text-white hover:bg-gray-700'
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={`w-full text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+              activeTab === key
+                ? 'bg-gray-100 text-gray-900'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
             }`}
           >
-            {saved_ ? 'Saved!' : 'Save'}
+            {label}
           </button>
+        ))}
+      </nav>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto bg-gray-50">
+        <div className="max-w-lg mx-auto py-8 px-4 space-y-6">
+          {/* General Tab */}
+          {activeTab === 'general' && (
+            <>
+              <div>
+                <h2 className="text-base font-semibold text-gray-900 mb-4">GitHub Connection</h2>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Personal Access Token
+                    </label>
+                    <input
+                      type="password"
+                      value={ghToken}
+                      onChange={(e) => setGhToken(e.target.value)}
+                      placeholder="ghp_…"
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p className="text-xs text-gray-400 mt-1">
+                      Classic PAT with <code>repo</code> and <code>project</code> scopes. Stored in
+                      localStorage only.
+                    </p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Owner</label>
+                    <input
+                      type="text"
+                      value={ghOwner}
+                      onChange={(e) => setGhOwner(e.target.value)}
+                      placeholder="github-username-or-org"
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Repository</label>
+                    <input
+                      type="text"
+                      value={ghRepo}
+                      onChange={(e) => setGhRepo(e.target.value)}
+                      placeholder="repo-name"
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-t border-gray-200 pt-6">
+                <h2 className="text-base font-semibold text-gray-900 mb-2">Firestore Sync</h2>
+                <p className="text-sm text-gray-500">
+                  Layout data (epic order, wave order, story positions) is automatically synced to
+                  Firestore when available. No configuration required.
+                </p>
+              </div>
+            </>
+          )}
+
+          {/* Describing Tab */}
+          {activeTab === 'describing' && (
+            <>
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="block text-sm font-medium text-gray-700">Gemini API Key</label>
+                  <Led state={ledState} onClick={handleTest} />
+                </div>
+                <input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => {
+                    setApiKey(e.target.value);
+                    setLedState('idle');
+                  }}
+                  placeholder="AIza…"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <p className="text-xs text-gray-400 mt-1">
+                  Stored in localStorage only. Used to auto-generate issue descriptions via Gemini.
+                </p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Model</label>
+                <input
+                  type="text"
+                  value={model}
+                  onChange={(e) => {
+                    setModel(e.target.value);
+                    setLedState('idle');
+                  }}
+                  placeholder={DEFAULT_GEMINI_MODEL}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Example Issues{' '}
+                  <span className="text-gray-400 font-normal">(up to 3 — sent as style references)</span>
+                </label>
+
+                {exampleNumbers.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mb-2">
+                    {exampleNumbers.map((num) => {
+                      const issue = issues.find((i) => i.number === num);
+                      return (
+                        <span
+                          key={num}
+                          className="flex items-center gap-1 px-2 py-1 bg-blue-50 text-blue-700 text-xs rounded-full border border-blue-200"
+                        >
+                          #{num}
+                          {issue ? ` · ${issue.title.slice(0, 28)}…` : ''}
+                          <button
+                            onClick={() => toggleExample(num)}
+                            className="hover:text-red-500 leading-none ml-0.5"
+                          >
+                            ×
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search issues…"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
+                />
+
+                <ul className="border border-gray-200 rounded-lg divide-y divide-gray-100 max-h-44 overflow-y-auto bg-white">
+                  {filtered.slice(0, 50).map((issue) => {
+                    const selected = exampleNumbers.includes(issue.number);
+                    const disabled = !selected && exampleNumbers.length >= 3;
+                    return (
+                      <li key={issue.number}>
+                        <button
+                          onClick={() => !disabled && toggleExample(issue.number)}
+                          disabled={disabled}
+                          className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 transition-colors ${
+                            selected
+                              ? 'bg-blue-50 text-blue-700'
+                              : disabled
+                              ? 'opacity-40 cursor-not-allowed text-gray-700'
+                              : 'hover:bg-gray-50 text-gray-700'
+                          }`}
+                        >
+                          <span className="text-gray-400 tabular-nums shrink-0 text-xs">
+                            #{issue.number}
+                          </span>
+                          <span className="truncate">{issue.title}</span>
+                          {selected && (
+                            <span className="ml-auto text-blue-500 shrink-0 text-xs">✓</span>
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                  {filtered.length === 0 && (
+                    <li className="px-3 py-3 text-sm text-gray-400">No issues found.</li>
+                  )}
+                </ul>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Additional Instructions
+                </label>
+                <textarea
+                  value={extraInstructions}
+                  onChange={(e) => setExtraInstructions(e.target.value)}
+                  rows={3}
+                  placeholder="e.g. Always write in Portuguese. Keep acceptance criteria concise."
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                />
+              </div>
+            </>
+          )}
+
+          {/* Coding Tab */}
+          {activeTab === 'coding' && (
+            <>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-base font-semibold text-gray-900">Code with AI</span>
+                <span className="text-xs bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full font-medium">
+                  beta
+                </span>
+              </div>
+              <p className="text-xs text-gray-400 -mt-2">
+                Triggers a Claude Managed Agent session to implement an issue — creating a branch,
+                writing code, and opening a PR. Requires a pre-configured agent with GitHub MCP access.
+              </p>
+
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Anthropic API Key
+                  </label>
+                  <input
+                    type="password"
+                    value={anthropicKey}
+                    onChange={(e) => setAnthropicKey(e.target.value)}
+                    placeholder="sk-ant-…"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Agent ID</label>
+                  <input
+                    type="text"
+                    value={agentId}
+                    onChange={(e) => setAgentId(e.target.value)}
+                    placeholder="agent_…"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Environment ID
+                  </label>
+                  <input
+                    type="text"
+                    value={envId}
+                    onChange={(e) => setEnvId(e.target.value)}
+                    placeholder="env_…"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Vault ID</label>
+                  <input
+                    type="text"
+                    value={vaultId}
+                    onChange={(e) => setVaultId(e.target.value)}
+                    placeholder="vlt_…"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400 font-mono"
+                  />
+                  <p className="text-xs text-gray-400 mt-1">
+                    The vault holds your GitHub OAuth token — the agent uses it automatically via
+                    GitHub MCP.
+                  </p>
+                </div>
+              </div>
+            </>
+          )}
+
+          <div className="flex justify-end pt-2">
+            <button
+              onClick={handleSave}
+              className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+                saved_ ? 'bg-green-600 text-white' : 'bg-gray-900 text-white hover:bg-gray-700'
+              }`}
+            >
+              {saved_ ? 'Saved!' : 'Save'}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -126,12 +126,10 @@ export default function SettingsView() {
     });
   }
 
-  const filtered = issues
-    .filter((i) => i.state === 'open')
-    .filter(
-      (i) =>
-        i.title.toLowerCase().includes(search.toLowerCase()) || String(i.number).includes(search),
-    );
+  const filtered = issues.filter(
+    (i) =>
+      i.title.toLowerCase().includes(search.toLowerCase()) || String(i.number).includes(search),
+  );
 
   return (
     <div className="flex-1 overflow-hidden flex">
@@ -257,11 +255,18 @@ export default function SettingsView() {
                   <div className="flex flex-wrap gap-1.5 mb-2">
                     {exampleNumbers.map((num) => {
                       const issue = issues.find((i) => i.number === num);
+                      const isClosed = issue?.state === 'closed';
                       return (
                         <span
                           key={num}
                           className="flex items-center gap-1 px-2 py-1 bg-blue-50 text-blue-700 text-xs rounded-full border border-blue-200"
                         >
+                          {isClosed && (
+                            <svg className="w-3 h-3 text-purple-600 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-label="Closed">
+                              <path d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"/>
+                              <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"/>
+                            </svg>
+                          )}
                           #{num}
                           {issue ? ` · ${issue.title.slice(0, 28)}…` : ''}
                           <button
@@ -288,6 +293,7 @@ export default function SettingsView() {
                   {filtered.slice(0, 50).map((issue) => {
                     const selected = exampleNumbers.includes(issue.number);
                     const disabled = !selected && exampleNumbers.length >= 3;
+                    const isClosed = issue.state === 'closed';
                     return (
                       <li key={issue.number}>
                         <button
@@ -301,6 +307,17 @@ export default function SettingsView() {
                               : 'hover:bg-gray-50 text-gray-700'
                           }`}
                         >
+                          {isClosed ? (
+                            <svg className="w-3.5 h-3.5 text-purple-600 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-label="Closed">
+                              <path d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"/>
+                              <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"/>
+                            </svg>
+                          ) : (
+                            <svg className="w-3.5 h-3.5 text-green-600 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-label="Open">
+                              <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/>
+                              <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/>
+                            </svg>
+                          )}
                           <span className="text-gray-400 tabular-nums shrink-0 text-xs">
                             #{issue.number}
                           </span>


### PR DESCRIPTION
## Summary
- Removed the `state === 'open'` filter from the example issues picker in Settings → Describing tab, so both open and closed issues are searchable and selectable.
- Added a purple closed icon (GitHub-style circle+checkmark SVG) next to closed issues in the list and in the selected-issue tags, making their state visually distinct at a glance.
- The Gemini API call in `gemini.ts` already fetches by issue number directly (endpoint `/repos/{owner}/{repo}/issues/{number}`), so it works for closed issues with no changes needed there.

## Implementation notes
- The store already fetches with `state: 'all'` (line 271 of `appStore.ts`), so closed issues were already in memory — the only blocker was the UI-side filter.
- Open issues get a green open-circle icon for symmetry and clarity when both states are visible in the same list.

## Test plan
- [ ] Open Settings → Describing tab, confirm closed issues appear in the example issues list alongside open ones.
- [ ] Verify closed issues display a purple circle-checkmark icon; open issues display a green open-circle icon.
- [ ] Select a closed issue as an example (up to 3 total); confirm the purple icon appears in the selected-tag chip.
- [ ] Trigger "Generate with AI" with a closed example selected; confirm generation completes successfully and the closed issue's body is reflected in the style.
- [ ] Search by title and by number for a closed issue; confirm it filters correctly.

Closes #47