### PR TITLE
Org/project clickable

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,9 +12,14 @@ export default function Header() {
         <div className="flex items-center justify-between">
           {/* Pill + Tabs */}
           <div className="flex items-center gap-1">
-            <span className="mr-2 px-2.5 py-1 text-xs font-medium bg-green-100 text-green-700 border border-green-200 rounded-full shrink-0">
+            <a
+              href={`https://github.com/${owner}/${repo}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mr-2 px-2.5 py-1 text-xs font-medium bg-green-100 text-green-700 border border-green-200 rounded-full shrink-0 cursor-pointer hover:brightness-95 transition-[filter]"
+            >
               {owner}/{repo}
-            </span>
+            </a>
             {(['grid', 'kanban', 'waves', 'epics', 'settings'] as const).map((v) => (
               <button
                 key={v}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
           {/* Pill + Tabs */}
           <div className="flex items-center gap-1">
             <a
-              href={`https://github.com/${owner}/${repo}`}
+              href={`https://github.com/${owner}/${repo}/issues`}
               target="_blank"
               rel="noopener noreferrer"
               className="mr-2 px-2.5 py-1 text-xs font-medium bg-green-100 text-green-700 border border-green-200 rounded-full shrink-0 cursor-pointer hover:brightness-95 transition-[filter]"


### PR DESCRIPTION
## Summary
- Replaced the static green repo pill in the header with an `<a>` tag linking to `https://github.com/{owner}/{repo}`.
- Link opens in a new tab with `target="_blank" rel="noopener noreferrer"` so the board stays open.
- Added `hover:brightness-95` and `cursor-pointer` for visual affordance.

## Implementation notes
- Only [Header.tsx:15](src/components/Header.tsx#L15) changed — a `<span>` swapped for an `<a>` with identical styling. No store or type changes needed.
- `transition-[filter]` makes the brightness hover smooth without touching the green color classes.

## Test plan
- [ ] Header pill shows a pointer cursor on hover.
- [ ] Hovering produces a subtle brightness change.
- [ ] Clicking opens the correct GitHub repo URL in a new tab.
- [ ] Original green pill styling (size, color, border, rounded-full) is unchanged.
- [ ] Board remains open in the original tab after clicking.

Closes #57