### PR TITLE
Waves view show list issues

### DIFF
--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -8,7 +8,6 @@ function SidebarItem({
   selected,
   onSelect,
   onUpdate,
-  onDelete,
   openCount,
   closedCount,
   owner,
@@ -18,7 +17,6 @@ function SidebarItem({
   selected: boolean;
   onSelect: () => void;
   onUpdate: (number: number, title: string, description: string) => Promise<void>;
-  onDelete: (number: number) => Promise<void>;
   openCount: number;
   closedCount: number;
   owner: string;
@@ -28,7 +26,6 @@ function SidebarItem({
   const [title, setTitle] = useState(milestone.title);
   const [description, setDescription] = useState(milestone.description ?? '');
   const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState('');
 
   async function handleSave() {
@@ -42,17 +39,6 @@ function SidebarItem({
       setError(err instanceof Error ? err.message : 'Failed to update');
     } finally {
       setSaving(false);
-    }
-  }
-
-  async function handleDelete() {
-    setDeleting(true);
-    setError('');
-    try {
-      await onDelete(milestone.number);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete');
-      setDeleting(false);
     }
   }
 
@@ -95,52 +81,39 @@ function SidebarItem({
   }
 
   return (
-    <div className={`group flex items-center border-b border-gray-100 ${selected ? 'bg-purple-50 border-r-2 border-r-purple-500' : 'hover:bg-gray-50'}`}>
-      <button
-        onClick={onSelect}
-        className="flex-1 text-left px-3 py-2.5 min-w-0"
-      >
-        <div className="flex items-center gap-1.5">
-          <span className={`block text-sm truncate ${selected ? 'font-medium text-purple-800' : 'text-gray-700'}`}>
-            {milestone.title}
-          </span>
-          <span className="shrink-0 text-xs text-gray-400 font-mono">#{milestone.number}</span>
-        </div>
-        <div className="flex items-center gap-1.5 mt-0.5">
-          <span className="text-xs text-green-600">{openCount} open</span>
-          <span className="text-xs text-gray-300">·</span>
-          <span className="text-xs text-gray-400">{closedCount} closed</span>
-          <a
-            href={`https://github.com/${owner}/${repo}/milestone/${milestone.number}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => e.stopPropagation()}
-            className="ml-auto shrink-0 text-gray-400 hover:text-blue-600 transition-colors"
-            title="View on GitHub"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
-              <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
-            </svg>
-          </a>
-        </div>
-      </button>
-      <div className="flex items-center gap-0.5 pr-2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
-          onClick={() => setEditing(true)}
-          className="p-1 text-gray-400 hover:text-gray-700 rounded hover:bg-gray-200 transition-colors text-xs"
+    <div
+      onClick={onSelect}
+      className={`flex flex-col border-b border-gray-100 px-3 py-2.5 cursor-pointer ${selected ? 'bg-purple-50 border-r-2 border-r-purple-500' : 'hover:bg-gray-50'}`}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          onClick={(e) => { e.stopPropagation(); onSelect(); setEditing(true); }}
+          className={`text-sm truncate cursor-text hover:underline ${selected ? 'font-medium text-purple-800' : 'text-gray-700'}`}
+          title="Click to edit"
         >
-          Edit
-        </button>
-        <button
-          onClick={handleDelete}
-          disabled={deleting}
-          className="p-1 text-gray-400 hover:text-red-600 rounded hover:bg-red-50 disabled:opacity-40 transition-colors text-xs"
-        >
-          {deleting ? '…' : 'Del'}
-        </button>
+          {milestone.title}
+        </span>
+        <span className="shrink-0 text-xs text-gray-400 font-mono">#{milestone.number}</span>
       </div>
-      {error && <p className="text-red-500 text-xs px-3 pb-1">{error}</p>}
+      <div className="flex items-center gap-1.5 mt-0.5">
+        <span className="text-xs text-green-600">{openCount} open</span>
+        <span className="text-xs text-gray-300">·</span>
+        <span className="text-xs text-gray-400">{closedCount} closed</span>
+        <a
+          href={`https://github.com/${owner}/${repo}/milestone/${milestone.number}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="ml-auto shrink-0 text-gray-400 hover:text-blue-600 transition-colors"
+          title="View on GitHub"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+            <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+          </svg>
+        </a>
+      </div>
+      {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
     </div>
   );
 }
@@ -155,6 +128,8 @@ export default function WavesView() {
   const [newDescription, setNewDescription] = useState('');
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
 
   const issueCounts = issues.reduce<Record<number, { open: number; closed: number }>>((acc, i) => {
     if (!i.milestone) return acc;
@@ -173,6 +148,20 @@ export default function WavesView() {
         return true;
       })
     : [];
+
+  async function handleDelete() {
+    if (!selected) return;
+    setDeleting(true);
+    setDeleteError('');
+    try {
+      await deleteMilestone(selected.number);
+      setSelectedNumber(null);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete');
+    } finally {
+      setDeleting(false);
+    }
+  }
 
   async function handleCreate() {
     if (!newTitle.trim()) return;
@@ -209,7 +198,6 @@ export default function WavesView() {
                 selected={m.number === selected?.number}
                 onSelect={() => setSelectedNumber(m.number)}
                 onUpdate={updateMilestone}
-                onDelete={deleteMilestone}
                 openCount={issueCounts[m.number]?.open ?? 0}
                 closedCount={issueCounts[m.number]?.closed ?? 0}
                 owner={owner}
@@ -273,7 +261,17 @@ export default function WavesView() {
         ) : (
           <div>
             <div className="mb-6">
-              <h1 className="text-2xl font-bold text-gray-900 mb-1">{selected.title}</h1>
+              <div className="flex items-start justify-between gap-4 mb-1">
+                <h1 className="text-2xl font-bold text-gray-900">{selected.title}</h1>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="shrink-0 text-sm text-red-500 hover:text-red-700 disabled:opacity-40 transition-colors mt-1"
+                >
+                  {deleting ? 'Deleting…' : 'Delete wave'}
+                </button>
+              </div>
+              {deleteError && <p className="text-xs text-red-600 mb-2">{deleteError}</p>}
               {selected.description && (
                 <p className="text-sm text-gray-500 mb-2">{selected.description}</p>
               )}

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -9,12 +9,20 @@ function SidebarItem({
   onSelect,
   onUpdate,
   onDelete,
+  openCount,
+  closedCount,
+  owner,
+  repo,
 }: {
   milestone: GitHubMilestone;
   selected: boolean;
   onSelect: () => void;
   onUpdate: (number: number, title: string, description: string) => Promise<void>;
   onDelete: (number: number) => Promise<void>;
+  openCount: number;
+  closedCount: number;
+  owner: string;
+  repo: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [title, setTitle] = useState(milestone.title);
@@ -92,12 +100,30 @@ function SidebarItem({
         onClick={onSelect}
         className="flex-1 text-left px-3 py-2.5 min-w-0"
       >
-        <span className={`block text-sm truncate ${selected ? 'font-medium text-purple-800' : 'text-gray-700'}`}>
-          {milestone.title}
-        </span>
-        {milestone.description && (
-          <span className="block text-xs text-gray-400 truncate mt-0.5">{milestone.description}</span>
-        )}
+        <div className="flex items-center gap-1.5">
+          <span className={`block text-sm truncate ${selected ? 'font-medium text-purple-800' : 'text-gray-700'}`}>
+            {milestone.title}
+          </span>
+          <span className="shrink-0 text-xs text-gray-400 font-mono">#{milestone.number}</span>
+        </div>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          <span className="text-xs text-green-600">{openCount} open</span>
+          <span className="text-xs text-gray-300">·</span>
+          <span className="text-xs text-gray-400">{closedCount} closed</span>
+          <a
+            href={`https://github.com/${owner}/${repo}/milestone/${milestone.number}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="ml-auto shrink-0 text-gray-400 hover:text-blue-600 transition-colors"
+            title="View on GitHub"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+              <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+            </svg>
+          </a>
+        </div>
       </button>
       <div className="flex items-center gap-0.5 pr-2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
         <button
@@ -129,6 +155,14 @@ export default function WavesView() {
   const [newDescription, setNewDescription] = useState('');
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState('');
+
+  const issueCounts = issues.reduce<Record<number, { open: number; closed: number }>>((acc, i) => {
+    if (!i.milestone) return acc;
+    const n = i.milestone.number;
+    if (!acc[n]) acc[n] = { open: 0, closed: 0 };
+    acc[n][i.state]++;
+    return acc;
+  }, {});
 
   const selected = milestones.find((m) => m.number === selectedNumber) ?? milestones[0] ?? null;
 
@@ -176,6 +210,10 @@ export default function WavesView() {
                 onSelect={() => setSelectedNumber(m.number)}
                 onUpdate={updateMilestone}
                 onDelete={deleteMilestone}
+                openCount={issueCounts[m.number]?.open ?? 0}
+                closedCount={issueCounts[m.number]?.closed ?? 0}
+                owner={owner}
+                repo={repo}
               />
             ))
           )}

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -266,9 +266,12 @@ export default function WavesView() {
                 <button
                   onClick={handleDelete}
                   disabled={deleting}
-                  className="shrink-0 text-sm text-red-500 hover:text-red-700 disabled:opacity-40 transition-colors mt-1"
+                  title="Delete wave permanently"
+                  className="shrink-0 text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 disabled:opacity-40 transition-colors mt-1"
                 >
-                  {deleting ? 'Deleting…' : 'Delete wave'}
+                  <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                  </svg>
                 </button>
               </div>
               {deleteError && <p className="text-xs text-red-600 mb-2">{deleteError}</p>}

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -123,6 +123,12 @@ export default function WavesView() {
   const [selectedNumber, setSelectedNumber] = useState<number | null>(
     milestones.length > 0 ? milestones[0].number : null,
   );
+
+  function selectMilestone(n: number) {
+    setSelectedNumber(n);
+    setEditingDetail(false);
+    setSaveDetailError('');
+  }
   const [showCreate, setShowCreate] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const [newDescription, setNewDescription] = useState('');
@@ -130,6 +136,11 @@ export default function WavesView() {
   const [createError, setCreateError] = useState('');
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState('');
+  const [editingDetail, setEditingDetail] = useState(false);
+  const [detailTitle, setDetailTitle] = useState('');
+  const [detailDescription, setDetailDescription] = useState('');
+  const [savingDetail, setSavingDetail] = useState(false);
+  const [saveDetailError, setSaveDetailError] = useState('');
 
   const issueCounts = issues.reduce<Record<number, { open: number; closed: number }>>((acc, i) => {
     if (!i.milestone) return acc;
@@ -148,6 +159,28 @@ export default function WavesView() {
         return true;
       })
     : [];
+
+  function startDetailEdit() {
+    if (!selected) return;
+    setDetailTitle(selected.title);
+    setDetailDescription(selected.description ?? '');
+    setSaveDetailError('');
+    setEditingDetail(true);
+  }
+
+  async function handleSaveDetail() {
+    if (!selected || !detailTitle.trim()) return;
+    setSavingDetail(true);
+    setSaveDetailError('');
+    try {
+      await updateMilestone(selected.number, detailTitle.trim(), detailDescription);
+      setEditingDetail(false);
+    } catch (err) {
+      setSaveDetailError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSavingDetail(false);
+    }
+  }
 
   async function handleDelete() {
     if (!selected) return;
@@ -196,7 +229,7 @@ export default function WavesView() {
                 key={m.number}
                 milestone={m}
                 selected={m.number === selected?.number}
-                onSelect={() => setSelectedNumber(m.number)}
+                onSelect={() => selectMilestone(m.number)}
                 onUpdate={updateMilestone}
                 openCount={issueCounts[m.number]?.open ?? 0}
                 closedCount={issueCounts[m.number]?.closed ?? 0}
@@ -261,40 +294,89 @@ export default function WavesView() {
         ) : (
           <div>
             <div className="mb-6">
-              <div className="flex items-start justify-between gap-4 mb-1">
-                <h1 className="text-2xl font-bold text-gray-900">{selected.title}</h1>
-                <button
-                  onClick={handleDelete}
-                  disabled={deleting}
-                  title="Delete wave permanently"
-                  className="shrink-0 text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 disabled:opacity-40 transition-colors mt-1"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-                  </svg>
-                </button>
-              </div>
-              {deleteError && <p className="text-xs text-red-600 mb-2">{deleteError}</p>}
-              {selected.description && (
-                <p className="text-sm text-gray-500 mb-2">{selected.description}</p>
+              {editingDetail ? (
+                <div className="space-y-3 max-w-2xl">
+                  <input
+                    autoFocus
+                    type="text"
+                    value={detailTitle}
+                    onChange={(e) => setDetailTitle(e.target.value)}
+                    placeholder="Wave title"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xl font-bold text-gray-900 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  />
+                  <textarea
+                    value={detailDescription}
+                    onChange={(e) => setDetailDescription(e.target.value)}
+                    placeholder="Description (optional)"
+                    rows={3}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none"
+                  />
+                  {saveDetailError && <p className="text-xs text-red-600">{saveDetailError}</p>}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleSaveDetail}
+                      disabled={savingDetail || !detailTitle.trim()}
+                      className="px-4 py-1.5 text-sm font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-700 disabled:opacity-40 transition-colors"
+                    >
+                      {savingDetail ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      onClick={() => setEditingDetail(false)}
+                      className="px-4 py-1.5 text-sm text-gray-600 hover:text-gray-900 rounded-lg hover:bg-gray-100 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-start justify-between gap-4 mb-1">
+                    <h1 className="text-2xl font-bold text-gray-900">{selected.title}</h1>
+                    <div className="flex items-center gap-1 mt-1">
+                      <button
+                        onClick={startDetailEdit}
+                        title="Edit wave"
+                        className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                          <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={handleDelete}
+                        disabled={deleting}
+                        title="Delete wave permanently"
+                        className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 disabled:opacity-40 transition-colors"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  {deleteError && <p className="text-xs text-red-600 mb-2">{deleteError}</p>}
+                  {selected.description && (
+                    <p className="text-sm text-gray-500 mb-2">{selected.description}</p>
+                  )}
+                  {selected.due_on && (
+                    <p className="text-xs text-gray-400 mb-2">
+                      Due {new Date(selected.due_on).toLocaleDateString()}
+                    </p>
+                  )}
+                  <a
+                    href={`https://github.com/${owner}/${repo}/milestone/${selected.number}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+                  >
+                    View on GitHub
+                    <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                    </svg>
+                  </a>
+                </>
               )}
-              {selected.due_on && (
-                <p className="text-xs text-gray-400 mb-2">
-                  Due {new Date(selected.due_on).toLocaleDateString()}
-                </p>
-              )}
-              <a
-                href={`https://github.com/${owner}/${repo}/milestone/${selected.number}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
-              >
-                View on GitHub
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
-                  <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
-                </svg>
-              </a>
             </div>
 
             {milestoneIssues.length === 0 ? (

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -1,13 +1,18 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import type { GitHubMilestone } from '../types';
+import IssueCard from './IssueCard';
 
-function MilestoneRow({
+function SidebarItem({
   milestone,
+  selected,
+  onSelect,
   onUpdate,
   onDelete,
 }: {
   milestone: GitHubMilestone;
+  selected: boolean;
+  onSelect: () => void;
   onUpdate: (number: number, title: string, description: string) => Promise<void>;
   onDelete: (number: number) => Promise<void>;
 }) {
@@ -45,36 +50,36 @@ function MilestoneRow({
 
   if (editing) {
     return (
-      <div className="p-3 rounded-lg border border-purple-200 bg-purple-50 space-y-2">
+      <div className="px-3 py-2 space-y-1.5 border-b border-gray-100">
         <input
           autoFocus
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Wave title"
-          className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+          className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-500"
         />
         <input
           type="text"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="Description (optional)"
-          className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+          className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-500"
         />
         {error && <p className="text-red-500 text-xs">{error}</p>}
-        <div className="flex gap-2 justify-end">
+        <div className="flex gap-1 justify-end">
           <button
             onClick={() => { setEditing(false); setTitle(milestone.title); setDescription(milestone.description ?? ''); }}
-            className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 rounded-lg hover:bg-gray-100 transition-colors"
+            className="px-2 py-0.5 text-xs text-gray-600 hover:text-gray-900 rounded hover:bg-gray-100 transition-colors"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={saving || !title.trim()}
-            className="px-3 py-1.5 text-sm font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="px-2 py-0.5 text-xs font-medium bg-gray-900 text-white rounded hover:bg-gray-700 disabled:opacity-40 transition-colors"
           >
-            {saving ? 'Saving…' : 'Save'}
+            {saving ? '…' : 'Save'}
           </button>
         </div>
       </div>
@@ -82,45 +87,58 @@ function MilestoneRow({
   }
 
   return (
-    <div className="flex items-start justify-between gap-3 p-3 rounded-lg hover:bg-gray-50 group">
-      <div className="min-w-0">
-        <p className="text-sm font-medium text-gray-900 truncate">{milestone.title}</p>
+    <div className={`group flex items-center border-b border-gray-100 ${selected ? 'bg-purple-50 border-r-2 border-r-purple-500' : 'hover:bg-gray-50'}`}>
+      <button
+        onClick={onSelect}
+        className="flex-1 text-left px-3 py-2.5 min-w-0"
+      >
+        <span className={`block text-sm truncate ${selected ? 'font-medium text-purple-800' : 'text-gray-700'}`}>
+          {milestone.title}
+        </span>
         {milestone.description && (
-          <p className="text-xs text-gray-500 mt-0.5 truncate">{milestone.description}</p>
+          <span className="block text-xs text-gray-400 truncate mt-0.5">{milestone.description}</span>
         )}
-        {milestone.due_on && (
-          <p className="text-xs text-gray-400 mt-0.5">
-            Due {new Date(milestone.due_on).toLocaleDateString()}
-          </p>
-        )}
-        {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
-      </div>
-      <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+      </button>
+      <div className="flex items-center gap-0.5 pr-2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
         <button
           onClick={() => setEditing(true)}
-          className="p-1.5 text-gray-400 hover:text-gray-700 rounded hover:bg-gray-200 transition-colors text-xs"
+          className="p-1 text-gray-400 hover:text-gray-700 rounded hover:bg-gray-200 transition-colors text-xs"
         >
           Edit
         </button>
         <button
           onClick={handleDelete}
           disabled={deleting}
-          className="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-red-50 disabled:opacity-40 transition-colors text-xs"
+          className="p-1 text-gray-400 hover:text-red-600 rounded hover:bg-red-50 disabled:opacity-40 transition-colors text-xs"
         >
-          {deleting ? '…' : 'Delete'}
+          {deleting ? '…' : 'Del'}
         </button>
       </div>
+      {error && <p className="text-red-500 text-xs px-3 pb-1">{error}</p>}
     </div>
   );
 }
 
 export default function WavesView() {
-  const { milestones, createMilestone, updateMilestone, deleteMilestone } = useAppStore();
+  const { milestones, issues, owner, repo, showClosedIssues, createMilestone, updateMilestone, deleteMilestone } = useAppStore();
+  const [selectedNumber, setSelectedNumber] = useState<number | null>(
+    milestones.length > 0 ? milestones[0].number : null,
+  );
   const [showCreate, setShowCreate] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const [newDescription, setNewDescription] = useState('');
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState('');
+
+  const selected = milestones.find((m) => m.number === selectedNumber) ?? milestones[0] ?? null;
+
+  const milestoneIssues = selected
+    ? issues.filter((i) => {
+        if (i.milestone?.number !== selected.number) return false;
+        if (!showClosedIssues && i.state === 'closed') return false;
+        return true;
+      })
+    : [];
 
   async function handleCreate() {
     if (!newTitle.trim()) return;
@@ -139,65 +157,117 @@ export default function WavesView() {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-8">
-      <div className="max-w-lg mx-auto">
-        {milestones.length === 0 ? (
-          <p className="text-sm text-gray-400 italic mb-4">No open waves yet</p>
-        ) : (
-          <div className="space-y-1 mb-4">
-            {milestones.map((m) => (
-              <MilestoneRow
+    <div className="flex-1 flex overflow-hidden">
+      {/* Sidebar */}
+      <div className="w-56 border-r border-gray-200 bg-white flex flex-col overflow-hidden shrink-0">
+        <div className="px-3 py-2.5 border-b border-gray-100">
+          <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Waves</h2>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {milestones.length === 0 ? (
+            <p className="px-3 py-3 text-xs text-gray-400 italic">No waves yet</p>
+          ) : (
+            milestones.map((m) => (
+              <SidebarItem
                 key={m.number}
                 milestone={m}
+                selected={m.number === selected?.number}
+                onSelect={() => setSelectedNumber(m.number)}
                 onUpdate={updateMilestone}
                 onDelete={deleteMilestone}
               />
-            ))}
-          </div>
-        )}
+            ))
+          )}
+        </div>
 
-        {showCreate ? (
-          <div className="space-y-2 border border-gray-200 rounded-lg p-3">
-            <input
-              autoFocus
-              type="text"
-              value={newTitle}
-              onChange={(e) => { setNewTitle(e.target.value); setCreateError(''); }}
-              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-              placeholder="Wave title"
-              className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-            <input
-              type="text"
-              value={newDescription}
-              onChange={(e) => setNewDescription(e.target.value)}
-              placeholder="Description (optional)"
-              className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-            {createError && <p className="text-red-500 text-xs">{createError}</p>}
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={() => { setShowCreate(false); setNewTitle(''); setNewDescription(''); setCreateError(''); }}
-                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 rounded-lg hover:bg-gray-100 transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleCreate}
-                disabled={creating || !newTitle.trim()}
-                className="px-3 py-1.5 text-sm font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                {creating ? 'Creating…' : 'Create'}
-              </button>
+        <div className="border-t border-gray-100 p-2">
+          {showCreate ? (
+            <div className="space-y-1.5">
+              <input
+                autoFocus
+                type="text"
+                value={newTitle}
+                onChange={(e) => { setNewTitle(e.target.value); setCreateError(''); }}
+                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                placeholder="Wave title"
+                className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+              <input
+                type="text"
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+                placeholder="Description (optional)"
+                className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+              {createError && <p className="text-red-500 text-xs">{createError}</p>}
+              <div className="flex gap-1 justify-end">
+                <button
+                  onClick={() => { setShowCreate(false); setNewTitle(''); setNewDescription(''); setCreateError(''); }}
+                  className="px-2 py-0.5 text-xs text-gray-600 hover:text-gray-900 rounded hover:bg-gray-100 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleCreate}
+                  disabled={creating || !newTitle.trim()}
+                  className="px-2 py-0.5 text-xs font-medium bg-gray-900 text-white rounded hover:bg-gray-700 disabled:opacity-40 transition-colors"
+                >
+                  {creating ? '…' : 'Create'}
+                </button>
+              </div>
             </div>
-          </div>
+          ) : (
+            <button
+              onClick={() => setShowCreate(true)}
+              className="w-full text-left text-xs text-gray-500 hover:text-gray-900 px-2 py-1.5 rounded hover:bg-gray-100 transition-colors"
+            >
+              + New Wave
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto p-8">
+        {!selected ? (
+          <p className="text-sm text-gray-400 italic">No waves found</p>
         ) : (
-          <button
-            onClick={() => setShowCreate(true)}
-            className="text-sm text-gray-600 hover:text-gray-900 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors"
-          >
-            + New Wave
-          </button>
+          <div>
+            <div className="mb-6">
+              <h1 className="text-2xl font-bold text-gray-900 mb-1">{selected.title}</h1>
+              {selected.description && (
+                <p className="text-sm text-gray-500 mb-2">{selected.description}</p>
+              )}
+              {selected.due_on && (
+                <p className="text-xs text-gray-400 mb-2">
+                  Due {new Date(selected.due_on).toLocaleDateString()}
+                </p>
+              )}
+              <a
+                href={`https://github.com/${owner}/${repo}/milestone/${selected.number}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+              >
+                View on GitHub
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                  <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                </svg>
+              </a>
+            </div>
+
+            {milestoneIssues.length === 0 ? (
+              <p className="text-sm text-gray-400 italic">No issues in this wave</p>
+            ) : (
+              <div className="space-y-2 max-w-2xl">
+                {milestoneIssues.map((issue) => (
+                  <IssueCard key={issue.number} issue={issue} />
+                ))}
+              </div>
+            )}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the flat Waves management list with a master-detail layout: sidebar of milestones + main content pane.
- Sidebar lists all milestones (selectable, with inline edit/delete on hover), defaults to the first one.
- Main pane shows the selected milestone's title, description, due date, a "View on GitHub" link, and all its issues rendered as `IssueCard` components (respects the show-closed-issues toggle).

## Implementation notes
- Issues are filtered from the existing store `issues` array by `milestone.number` — no new API calls needed.
- Edit/delete/create CRUD for milestones is preserved in the sidebar to avoid regression.
- GitHub milestone URL constructed as `https://github.com/{owner}/{repo}/milestone/{number}`.

## Test plan
- Open the Waves tab — sidebar shows all milestones, first one is selected by default.
- Click a different milestone — main pane updates title, link, and issue list.
- "View on GitHub" link opens the correct GitHub milestone page in a new tab.
- Issues listed match those assigned to the milestone in GitHub.
- Toggle show/hide closed issues — closed issues appear/disappear in the list.
- Hover a sidebar item — Edit/Del buttons appear; edit and delete work as before.
- "+ New Wave" creates a new milestone and it appears in the sidebar.

Closes #60