### PR TITLE
Allow moving closed issues in Grid and Kanban views

### DIFF
--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -89,6 +89,7 @@ export default function IssueCard({ issue }: Props) {
     if (!confirm(`Close issue #${issue.number}?`)) return;
     setBusy(true);
     try { await closeIssue(issue.number); } catch { setBusy(false); }
+    setBusy(false);
   }
 
   async function handleReopen(e: React.MouseEvent) {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -435,7 +435,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       storyOrder: newStoryOrder,
     };
 
-    set({ issues: issues.filter((i) => i.number !== number), layout: newLayout });
+    set({
+      issues: issues.map((i) => i.number === number ? { ...i, state: 'closed' as const } : i),
+      layout: newLayout,
+    });
     saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
   },
 


### PR DESCRIPTION
## Summary

- `closeIssue` in the store was removing the issue from the `issues` array entirely — meaning session-closed issues vanished from the store and could never appear on the board (even with "show closed issues" enabled), making them impossible to drag.
- Changed `closeIssue` to update `state: 'closed'` in place instead of filtering the issue out, so closed issues remain available for display and drag when `showClosedIssues` is true.
- Fixed `handleClose` in `IssueCard` to reset `busy` after a successful close (matching the existing `handleReopen` pattern), preventing the card from being stuck with `pointer-events-none` when the issue stays visible.

## Implementation notes

- Issues closed before the app loaded were already fetched with `state: 'all'` and were in the store as `state: 'closed'` — but issues closed in the same session were being removed instead of updated, causing the asymmetry.
- `deleteIssue` (the other caller of the same filter pattern) is intentionally left unchanged — permanent deletion should still remove the issue from the store.
- No changes to drag infrastructure were needed: `Draggable` components already had no `isDragDisabled` restriction, and `moveIssueInGrid`/`moveIssueInKanbanByProject` already handle closed issues without reopening them.

## Test plan

- [ ] Close an issue while "Show Closed Issues" is enabled → issue stays visible on the board with `opacity-60`, card is fully interactive.
- [ ] Drag a just-closed issue to a different wave row (milestone) → board reflects the new wave immediately, GitHub milestone is updated.
- [ ] Drag a just-closed issue to a different epic column (project) → board reflects the new epic, GitHub project membership is updated.
- [ ] Drag a closed issue in Kanban to a different status column → status updates in the project, issue remains closed.
- [ ] Toggle "Show Closed Issues" off → closed issue disappears; toggle back on → it reappears in its new position.
- [ ] Reload the page → closed issues reappear in correct cells, still draggable.
- [ ] Deleting an issue still removes it from the board entirely.
- [ ] Reopening a closed issue restores it to open state without errors.

Closes #52