### PR TITLE
Column resize shouldn't drag column

### DIFF
--- a/src/components/ResizableHeader.tsx
+++ b/src/components/ResizableHeader.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback, forwardRef } from 'react';
+import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 
 export const GRID_DEFAULT_WIDTH = 200;
 export const KANBAN_DEFAULT_WIDTH = 280;
@@ -14,20 +15,29 @@ interface ResizableHeaderProps extends React.ThHTMLAttributes<HTMLTableCellEleme
   onResize: (key: string, width: number) => void;
   /** Colour theme of the visual handle indicator. */
   handleVariant?: 'blue' | 'green';
+  /**
+   * When provided, the drag-handle props are applied to an inner wrapper div
+   * around the children instead of the <th> itself. This prevents the resize
+   * handle — a sibling of that wrapper — from being found by
+   * `event.target.closest('[data-rfd-drag-handle-context-id]')`, which the
+   * @hello-pangea/dnd window-level capture listener uses to detect drags.
+   */
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
 }
 
 /**
- * A `<th>` wrapper that renders a draggable resize handle on its right edge.
+ * A `<th>` wrapper that renders a drag-to-resize handle on its right edge.
  *
  * Supports React `forwardRef` so it works seamlessly inside
  * `@hello-pangea/dnd` Draggable render props that require `provided.innerRef`.
  *
- * The resize handle calls `e.stopPropagation()` on `mousedown` so that it
- * does NOT accidentally trigger a DnD column-reorder drag.
+ * Pass `dragHandleProps={provided.dragHandleProps}` instead of spreading them
+ * directly on this component. The component places them on an inner content
+ * div so the resize handle (a sibling) cannot trigger a column-reorder drag.
  */
 const ResizableHeader = forwardRef<HTMLTableCellElement, ResizableHeaderProps>(
   function ResizableHeader(
-    { columnKey, width, onResize, handleVariant = 'blue', style, className, children, ...rest },
+    { columnKey, width, onResize, handleVariant = 'blue', style, className, children, dragHandleProps, ...rest },
     ref,
   ) {
     const startXRef = useRef<number>(0);
@@ -35,7 +45,6 @@ const ResizableHeader = forwardRef<HTMLTableCellElement, ResizableHeaderProps>(
 
     const handleMouseDown = useCallback(
       (e: React.MouseEvent<HTMLDivElement>) => {
-        // Prevent the parent DnD drag-handle from starting a column-reorder drag.
         e.preventDefault();
         e.stopPropagation();
 
@@ -58,7 +67,6 @@ const ResizableHeader = forwardRef<HTMLTableCellElement, ResizableHeaderProps>(
           document.body.style.userSelect = '';
         };
 
-        // Override cursor and text-selection for the whole page while dragging.
         document.body.style.cursor = 'col-resize';
         document.body.style.userSelect = 'none';
         document.addEventListener('mousemove', onMouseMove);
@@ -76,12 +84,16 @@ const ResizableHeader = forwardRef<HTMLTableCellElement, ResizableHeaderProps>(
       <th
         ref={ref}
         {...rest}
-        // Width is set via inline style so it overrides class-based constraints.
-        // The DnD style prop (transform, etc.) is merged last so it is not lost.
         style={{ width, minWidth: width, ...style }}
         className={`relative group/colresize ${className ?? ''}`}
       >
-        {children}
+        {dragHandleProps ? (
+          <div {...(dragHandleProps as React.HTMLAttributes<HTMLDivElement>)}>
+            {children}
+          </div>
+        ) : (
+          children
+        )}
 
         {/* Drag-to-resize handle — pinned to the right edge of the header */}
         <div

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -285,7 +285,7 @@ export default function StoryMap() {
                           <ResizableHeader
                             ref={provided.innerRef}
                             {...provided.draggableProps}
-                            {...provided.dragHandleProps}
+                            dragHandleProps={provided.dragHandleProps}
                             columnKey={project.id}
                             width={colW(project.id)}
                             onResize={setColumnWidth}


### PR DESCRIPTION
## Summary

- Dragging the resize handle on a column header was also triggering a column-reorder drag via `@hello-pangea/dnd`.
- The existing `e.stopPropagation()` / `e.preventDefault()` call on the resize handle's `mousedown` was ineffective: dnd registers a **window-level capture-phase** listener that fires before React's synthetic events reach the resize handle element.
- Fixed by moving the dnd `dragHandleProps` from the `<th>` element itself to an inner content wrapper `<div>`. The resize handle is a sibling of that wrapper, so `event.target.closest('[data-rfd-drag-handle-context-id]')` (dnd's drag-target lookup) can no longer traverse through the resize zone — the drag handle attribute is no longer an ancestor of the resize handle.

## Implementation notes

- `ResizableHeader` now accepts an optional `dragHandleProps` prop (`DraggableProvidedDragHandleProps | null`). When provided, the props are spread on an inner `<div>` wrapping `children` instead of on the `<th>`.
- In `StoryMap.tsx`, `{...provided.dragHandleProps}` spread on `<ResizableHeader>` is replaced with `dragHandleProps={provided.dragHandleProps}`. The `draggableProps` (which carry the transform/position styles) stay spread on the `<th>` as before.
- Row-label drag handles (plain `<th>` elements for milestones) are unaffected — they don't use `ResizableHeader`.
- Kanban column headers use `ResizableHeader` but are not draggable, so they pass no `dragHandleProps` and are unaffected.

## Test plan

- [ ] Drag the **right edge** of a column header to resize it → column resizes, no column-reorder drag initiates.
- [ ] Drag the **title text area** of a column header → column-reorder drag works as before.
- [ ] Resize a column, then drag-reorder it → both operations work independently.
- [ ] Resize handle cursor (`col-resize`) appears on hover over the right edge; grab cursor appears over the title area.
- [ ] Row (wave) drag-reorder still works correctly.
- [ ] Kanban status columns resize correctly (unrelated code path, no regression).

Closes #31