### PR TITLE
Timeline view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import KanbanView from './components/KanbanView';
 import WavesView from './components/WavesView';
 import UserActivitiesView from './components/UserActivitiesView';
 import RoadmapView from './components/RoadmapView';
+import TimelineView from './components/TimelineView';
 import SettingsView from './components/SettingsView';
 
 export default function App() {
@@ -51,6 +52,7 @@ export default function App() {
           {view === 'waves' && <WavesView />}
           {view === 'user-activities' && <UserActivitiesView />}
           {view === 'roadmap' && <RoadmapView />}
+          {view === 'timeline' && <TimelineView />}
           {view === 'settings' && <SettingsView />}
         </div>
       )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone, timelineGranularity, setTimelineGranularity } = useAppStore();
+  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone } = useAppStore();
   const [showCreate, setShowCreate] = useState(false);
 
   return (
@@ -47,20 +47,6 @@ export default function Header() {
               {milestones.map((m) => (
                 <option key={m.number} value={m.number}>{m.title}</option>
               ))}
-            </select>
-          )}
-
-          {/* Timeline granularity selector */}
-          {view === 'timeline' && (
-            <select
-              value={timelineGranularity}
-              onChange={(e) => setTimelineGranularity(e.target.value as 'day' | 'week' | 'quarter' | 'year')}
-              className="self-center ml-3 text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-400"
-            >
-              <option value="day">Day</option>
-              <option value="week">Week</option>
-              <option value="quarter">Quarter</option>
-              <option value="year">Year</option>
             </select>
           )}
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone } = useAppStore();
+  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, milestones, kanbanMilestoneNumber, setKanbanMilestone, timelineGranularity, setTimelineGranularity } = useAppStore();
   const [showCreate, setShowCreate] = useState(false);
 
   return (
@@ -20,7 +20,7 @@ export default function Header() {
             >
               {owner}/{repo}
             </a>
-            {(['grid', 'kanban', 'roadmap', 'waves', 'user-activities', 'settings'] as const).map((v) => (
+            {(['grid', 'kanban', 'roadmap', 'timeline', 'waves', 'user-activities', 'settings'] as const).map((v) => (
               <button
                 key={v}
                 onClick={() => setView(v)}
@@ -30,7 +30,7 @@ export default function Header() {
                     : 'text-gray-500 hover:text-gray-700'
                 }`}
               >
-                {v === 'grid' ? 'Story Map' : v === 'kanban' ? 'Kanban' : v === 'waves' ? 'Waves' : v === 'user-activities' ? 'User Activities' : v === 'roadmap' ? 'Roadmap' : 'Settings'}
+                {v === 'grid' ? 'Story Map' : v === 'kanban' ? 'Kanban' : v === 'waves' ? 'Waves' : v === 'user-activities' ? 'User Activities' : v === 'roadmap' ? 'Roadmap' : v === 'timeline' ? 'Timeline' : 'Settings'}
               </button>
             ))}
           </div>
@@ -47,6 +47,20 @@ export default function Header() {
               {milestones.map((m) => (
                 <option key={m.number} value={m.number}>{m.title}</option>
               ))}
+            </select>
+          )}
+
+          {/* Timeline granularity selector */}
+          {view === 'timeline' && (
+            <select
+              value={timelineGranularity}
+              onChange={(e) => setTimelineGranularity(e.target.value as 'day' | 'week' | 'quarter' | 'year')}
+              className="self-center ml-3 text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-400"
+            >
+              <option value="day">Day</option>
+              <option value="week">Week</option>
+              <option value="quarter">Quarter</option>
+              <option value="year">Year</option>
             </select>
           )}
 

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -278,7 +278,17 @@ export default function TimelineView() {
               : 'bg-white border-gray-200 text-gray-400 hover:text-gray-600'
           }`}
         >
-          <span className="inline-block w-2.5 h-2.5 rounded-full bg-purple-400" />
+          {timelineShowIssues ? (
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
+              <path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clipRule="evenodd" />
+              <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.064 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
+            </svg>
+          )}
           Issues
         </button>
 

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -134,6 +134,27 @@ function issueStatusColor(issue: GitHubIssue, kanbanStatuses: Record<number, str
   return githubColorToHex(kanbanStatusColors[status] ?? '');
 }
 
+function issueStatusLabel(issue: GitHubIssue, kanbanStatuses: Record<number, string>): string {
+  if (issue.state === 'closed') return 'Closed';
+  return kanbanStatuses[issue.number] ?? issue.labels.find((l) => l.name.startsWith('s_'))?.name.slice(2) ?? 'No status';
+}
+
+function IssueDot({ issue, x, y, color, label }: { issue: GitHubIssue; x: number; y: number; color: string; label: string }) {
+  return (
+    <div className="absolute group" style={{ left: x, top: y }}>
+      <div className="w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer" style={{ background: color }} />
+      <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 z-50 rounded bg-gray-900 px-2.5 py-1.5 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-2 h-2 rounded-full flex-shrink-0" style={{ background: color }} />
+          <span className="text-gray-400 font-mono">#{issue.number}</span>
+          <span className="max-w-[220px] truncate">{issue.title}</span>
+          <span className="text-gray-400 pl-2">{label}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export default function TimelineView() {
   const { milestones, issues, layout, setWaveDate, timelineGranularity, setTimelineGranularity, kanbanIssueStatuses, kanbanStatusColumns, kanbanStatusColors } = useAppStore();
 
@@ -357,19 +378,23 @@ export default function TimelineView() {
                 )}
                 {/* Issue dots */}
                 {closedIssues.map((issue) => (
-                  <div
+                  <IssueDot
                     key={issue.number}
-                    className="absolute w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer"
-                    style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT - 22, background: CLOSED_COLOR }}
-                    title={`#${issue.number}: ${issue.title}`}
+                    issue={issue}
+                    x={dToX(new Date(issue.closed_at!))}
+                    y={ROW_HEIGHT - 22}
+                    color={CLOSED_COLOR}
+                    label="Closed"
                   />
                 ))}
                 {openIssues.map((issue, idx) => (
-                  <div
+                  <IssueDot
                     key={issue.number}
-                    className="absolute w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer"
-                    style={{ left: openDotX + idx * 2, top: ROW_HEIGHT - 22, background: issueStatusColor(issue, kanbanIssueStatuses, kanbanStatusColors) }}
-                    title={`#${issue.number}: ${issue.title}`}
+                    issue={issue}
+                    x={openDotX + idx * 2}
+                    y={ROW_HEIGHT - 22}
+                    color={issueStatusColor(issue, kanbanIssueStatuses, kanbanStatusColors)}
+                    label={issueStatusLabel(issue, kanbanIssueStatuses)}
                   />
                 ))}
               </div>
@@ -394,11 +419,13 @@ export default function TimelineView() {
                 <div className="absolute top-0 bottom-0 w-px bg-red-200 pointer-events-none" style={{ left: todayX }} />
               )}
               {noWaveIssues.map((issue) => (
-                <div
+                <IssueDot
                   key={issue.number}
-                  className="absolute w-2.5 h-2.5 rounded-full bg-gray-400 -translate-x-[5px] cursor-pointer hover:bg-gray-600 transition-colors"
-                  style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT - 22 }}
-                  title={`#${issue.number}: ${issue.title}`}
+                  issue={issue}
+                  x={dToX(new Date(issue.closed_at!))}
+                  y={ROW_HEIGHT - 22}
+                  color={CLOSED_COLOR}
+                  label="Closed"
                 />
               ))}
             </div>

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -132,6 +132,7 @@ function issueStatusColor(issue: GitHubIssue, kanbanStatuses: Record<number, str
   if (issue.state === 'closed') return CLOSED_COLOR;
   const status = kanbanStatuses[issue.number] ?? issue.labels.find((l) => l.name.startsWith('s_'))?.name.slice(2);
   if (!status) return NO_STATUS_COLOR;
+  if (statusSortKey(status) === 2) return CLOSED_COLOR;
   return githubColorToHex(kanbanStatusColors[status] ?? '');
 }
 
@@ -299,15 +300,17 @@ export default function TimelineView() {
               <span key={status} className="flex items-center gap-1.5">
                 <span
                   className="inline-block w-3 h-3 rounded-full"
-                  style={{ background: githubColorToHex(kanbanStatusColors[status] ?? '') }}
+                  style={{ background: statusSortKey(status) === 2 ? CLOSED_COLOR : githubColorToHex(kanbanStatusColors[status] ?? '') }}
                 />
                 {status}
               </span>
             ))}
-          <span className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded-full" style={{ background: CLOSED_COLOR }} />
-            Closed
-          </span>
+          {!kanbanStatusColumns.some((s) => statusSortKey(s) === 2) && (
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded-full" style={{ background: CLOSED_COLOR }} />
+              Closed
+            </span>
+          )}
         </div>
       </div>
 

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -108,8 +108,16 @@ function sortedMilestones(milestones: GitHubMilestone[], order: number[]): GitHu
   });
 }
 
+type IssueStatus = 'closed' | 'in-progress' | 'todo';
+
+function issueStatus(issue: GitHubIssue, kanbanStatuses: Record<number, string>): IssueStatus {
+  if (issue.state === 'closed') return 'closed';
+  const raw = (kanbanStatuses[issue.number] ?? issue.labels.find((l) => l.name.startsWith('s_'))?.name.slice(2) ?? '').toLowerCase();
+  return raw === 'to do' || raw === 'todo' || raw === '' ? 'todo' : 'in-progress';
+}
+
 export default function TimelineView() {
-  const { milestones, issues, layout, setWaveDate, timelineGranularity } = useAppStore();
+  const { milestones, issues, layout, setWaveDate, timelineGranularity, kanbanIssueStatuses } = useAppStore();
 
   const g = timelineGranularity;
   const tw = TICK_WIDTH[g];
@@ -241,9 +249,13 @@ export default function TimelineView() {
           const startX = dToX(new Date(dates.start));
           const endX = dToX(new Date(dates.end));
           const barWidth = Math.max(0, endX - startX);
-          const waveIssues = issues.filter(
-            (i) => i.milestone?.number === m.number && i.state === 'closed' && i.closed_at,
-          );
+          const waveIssues = issues.filter((i) => i.milestone?.number === m.number);
+          const closedIssues = waveIssues.filter((i) => i.state === 'closed' && i.closed_at);
+          const openIssues = waveIssues.filter((i) => i.state === 'open');
+          const todayMs = Date.now();
+          const waveStartMs = new Date(dates.start).getTime();
+          const waveEndMs = new Date(dates.end).getTime();
+          const openDotX = dToX(new Date(Math.min(Math.max(todayMs, waveStartMs), waveEndMs)));
           return (
             <div key={m.number} className="flex border-b border-gray-100" style={{ height: ROW_HEIGHT }}>
               <div
@@ -291,7 +303,7 @@ export default function TimelineView() {
                   </div>
                 )}
                 {/* Closed issue dots */}
-                {waveIssues.map((issue) => (
+                {closedIssues.map((issue) => (
                   <div
                     key={issue.number}
                     className="absolute w-2.5 h-2.5 rounded-full bg-purple-500 -translate-x-[5px] cursor-pointer hover:bg-purple-700 transition-colors"
@@ -299,6 +311,22 @@ export default function TimelineView() {
                     title={`#${issue.number}: ${issue.title}`}
                   />
                 ))}
+                {/* In-progress / todo dots at today (clamped to wave range) */}
+                {openIssues.map((issue, idx) => {
+                  const status = issueStatus(issue, kanbanIssueStatuses);
+                  return (
+                    <div
+                      key={issue.number}
+                      className={`absolute w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer transition-colors border ${
+                        status === 'in-progress'
+                          ? 'bg-orange-400 border-orange-500 hover:bg-orange-600'
+                          : 'bg-white border-gray-400 hover:border-gray-600'
+                      }`}
+                      style={{ left: openDotX + idx * 2, top: ROW_HEIGHT - 22 }}
+                      title={`#${issue.number}: ${issue.title} (${status})`}
+                    />
+                  );
+                })}
               </div>
             </div>
           );

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue, GitHubMilestone } from '../types';
 import IssueReadModal from './IssueReadModal';
@@ -166,6 +166,8 @@ export default function TimelineView() {
   const [selectedIssue, setSelectedIssue] = useState<GitHubIssue | null>(null);
   const [localDates, setLocalDates] = useState<Record<number, { start: string; end: string }>>({});
   const localDatesRef = useRef<Record<number, { start: string; end: string }>>({});
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isFirstScroll = useRef(true);
   const dragRef = useRef<{
     milestoneNumber: number;
     edge: 'start' | 'end';
@@ -210,6 +212,16 @@ export default function TimelineView() {
 
   const dToX = (d: Date) => dateToX(d, ticks, tw);
   const xToD = (x: number) => xToDate(x, ticks, tw);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !ticks.length) return;
+    const todayXValue = dateToX(new Date(), ticks, tw);
+    const containerWidth = container.clientWidth;
+    const targetLeft = Math.max(0, LABEL_WIDTH + todayXValue - containerWidth / 2);
+    container.scrollTo({ left: targetLeft, behavior: isFirstScroll.current ? 'instant' : 'smooth' });
+    isFirstScroll.current = false;
+  }, [ticks, tw]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function startEdgeDrag(e: React.MouseEvent, m: GitHubMilestone, edge: 'start' | 'end') {
     e.preventDefault();
@@ -315,7 +327,7 @@ export default function TimelineView() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto" style={{ minWidth: 0 }}>
+      <div ref={scrollContainerRef} className="flex-1 overflow-auto" style={{ minWidth: 0 }}>
       <div style={{ minWidth: LABEL_WIDTH + totalWidth }}>
 
         {/* Time axis header */}

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -5,7 +5,7 @@ import IssueReadModal from './IssueReadModal';
 
 type Granularity = 'day' | 'week' | 'quarter' | 'year';
 
-const TICK_WIDTH: Record<Granularity, number> = { day: 44, week: 80, quarter: 110, year: 90 };
+const TICK_WIDTH: Record<Granularity, number> = { day: 44, week: 160, quarter: 440, year: 90 };
 const LABEL_WIDTH = 160;
 const ROW_HEIGHT = 72;
 const HEADER_HEIGHT = 40;
@@ -201,8 +201,9 @@ export default function TimelineView() {
     const now = Date.now();
     const minMs = allMs.length ? Math.min(...allMs) : now - 30 * 86400_000;
     const maxMs = allMs.length ? Math.max(...allMs) : now + 30 * 86400_000;
-    const rangeStart = floorToGranularity(new Date(minMs), g);
-    const padEnd = addTick(floorToGranularity(new Date(maxMs), g), g);
+    const sixMonths = 6 * 30 * 86400_000;
+    const rangeStart = floorToGranularity(new Date(minMs - sixMonths), g);
+    const padEnd = addTick(floorToGranularity(new Date(maxMs + sixMonths), g), g);
     const t = generateTicks(rangeStart, padEnd, g);
     return { ticks: t, totalWidth: t.length * tw };
   }, [ordered, effectiveDates, issues, g, tw]);

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -117,7 +117,7 @@ function issueStatus(issue: GitHubIssue, kanbanStatuses: Record<number, string>)
 }
 
 export default function TimelineView() {
-  const { milestones, issues, layout, setWaveDate, timelineGranularity, kanbanIssueStatuses } = useAppStore();
+  const { milestones, issues, layout, setWaveDate, timelineGranularity, setTimelineGranularity, kanbanIssueStatuses } = useAppStore();
 
   const g = timelineGranularity;
   const tw = TICK_WIDTH[g];
@@ -212,7 +212,39 @@ export default function TimelineView() {
   const todayX = ticks.length ? dToX(new Date()) : null;
 
   return (
-    <div className="flex-1 overflow-auto h-full" style={{ minWidth: 0 }}>
+    <div className="flex-1 flex flex-col overflow-hidden h-full" style={{ minWidth: 0 }}>
+      {/* Toolbar */}
+      <div className="flex items-center gap-4 px-4 py-2 border-b border-gray-100 shrink-0 flex-wrap">
+        <div className="flex rounded border border-gray-200 overflow-hidden text-xs">
+          {(['day', 'week', 'quarter', 'year'] as const).map((opt, i) => (
+            <button
+              key={opt}
+              onClick={() => setTimelineGranularity(opt)}
+              className={`px-3 py-1 capitalize transition-colors ${i > 0 ? 'border-l border-gray-200' : ''} ${
+                timelineGranularity === opt ? 'bg-gray-100 font-medium text-gray-800' : 'bg-white text-gray-400 hover:text-gray-600'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-3 text-xs text-gray-500">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-full bg-purple-500" />
+            Closed
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-full bg-orange-400" />
+            In Progress
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-full bg-white border border-gray-400" />
+            To Do
+          </span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto" style={{ minWidth: 0 }}>
       <div style={{ minWidth: LABEL_WIDTH + totalWidth }}>
 
         {/* Time axis header */}
@@ -365,6 +397,7 @@ export default function TimelineView() {
             No waves or closed issues to display.
           </div>
         )}
+      </div>
       </div>
     </div>
   );

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue, GitHubMilestone } from '../types';
+import IssueReadModal from './IssueReadModal';
 
 type Granularity = 'day' | 'week' | 'quarter' | 'year';
 
@@ -139,10 +140,10 @@ function issueStatusLabel(issue: GitHubIssue, kanbanStatuses: Record<number, str
   return kanbanStatuses[issue.number] ?? issue.labels.find((l) => l.name.startsWith('s_'))?.name.slice(2) ?? 'No status';
 }
 
-function IssueDot({ issue, x, y, color, label }: { issue: GitHubIssue; x: number; y: number; color: string; label: string }) {
+function IssueDot({ issue, x, y, color, label, onClick }: { issue: GitHubIssue; x: number; y: number; color: string; label: string; onClick: () => void }) {
   return (
     <div className="absolute group" style={{ left: x, top: y }}>
-      <div className="w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer" style={{ background: color }} />
+      <div className="w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer" style={{ background: color }} onClick={onClick} />
       <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 z-50 rounded bg-gray-900 px-2.5 py-1.5 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
         <span className="flex items-center gap-1.5">
           <span className="inline-block w-2 h-2 rounded-full flex-shrink-0" style={{ background: color }} />
@@ -161,6 +162,7 @@ export default function TimelineView() {
   const g = timelineGranularity;
   const tw = TICK_WIDTH[g];
 
+  const [selectedIssue, setSelectedIssue] = useState<GitHubIssue | null>(null);
   const [localDates, setLocalDates] = useState<Record<number, { start: string; end: string }>>({});
   const localDatesRef = useRef<Record<number, { start: string; end: string }>>({});
   const dragRef = useRef<{
@@ -251,6 +253,7 @@ export default function TimelineView() {
   const todayX = ticks.length ? dToX(new Date()) : null;
 
   return (
+    <>
     <div className="flex-1 flex flex-col overflow-hidden h-full" style={{ minWidth: 0 }}>
       {/* Toolbar */}
       <div className="flex items-center gap-4 px-4 py-2 border-b border-gray-100 shrink-0 flex-wrap">
@@ -385,6 +388,7 @@ export default function TimelineView() {
                     y={ROW_HEIGHT - 22}
                     color={CLOSED_COLOR}
                     label="Closed"
+                    onClick={() => setSelectedIssue(issue)}
                   />
                 ))}
                 {openIssues.map((issue, idx) => (
@@ -395,6 +399,7 @@ export default function TimelineView() {
                     y={ROW_HEIGHT - 22}
                     color={issueStatusColor(issue, kanbanIssueStatuses, kanbanStatusColors)}
                     label={issueStatusLabel(issue, kanbanIssueStatuses)}
+                    onClick={() => setSelectedIssue(issue)}
                   />
                 ))}
               </div>
@@ -426,6 +431,7 @@ export default function TimelineView() {
                   y={ROW_HEIGHT - 22}
                   color={CLOSED_COLOR}
                   label="Closed"
+                  onClick={() => setSelectedIssue(issue)}
                 />
               ))}
             </div>
@@ -440,5 +446,7 @@ export default function TimelineView() {
       </div>
       </div>
     </div>
+    {selectedIssue && <IssueReadModal issue={selectedIssue} onClose={() => setSelectedIssue(null)} />}
+    </>
   );
 }

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -157,7 +157,7 @@ function IssueDot({ issue, x, y, color, label, onClick }: { issue: GitHubIssue; 
 }
 
 export default function TimelineView() {
-  const { milestones, issues, layout, setWaveDate, timelineGranularity, setTimelineGranularity, kanbanIssueStatuses, kanbanStatusColumns, kanbanStatusColors } = useAppStore();
+  const { milestones, issues, layout, setWaveDate, timelineGranularity, setTimelineGranularity, timelineShowIssues, toggleTimelineShowIssues, kanbanIssueStatuses, kanbanStatusColumns, kanbanStatusColors } = useAppStore();
 
   const g = timelineGranularity;
   const tw = TICK_WIDTH[g];
@@ -270,6 +270,18 @@ export default function TimelineView() {
             </button>
           ))}
         </div>
+        <button
+          onClick={toggleTimelineShowIssues}
+          className={`flex items-center gap-1.5 px-3 py-1 rounded border text-xs transition-colors ${
+            timelineShowIssues
+              ? 'bg-gray-100 border-gray-300 text-gray-700 font-medium'
+              : 'bg-white border-gray-200 text-gray-400 hover:text-gray-600'
+          }`}
+        >
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-purple-400" />
+          Issues
+        </button>
+
         <div className="flex items-center gap-3 text-xs text-gray-500 flex-wrap">
           {[...kanbanStatusColumns]
             .sort((a, b) => statusSortKey(a) - statusSortKey(b))
@@ -380,7 +392,7 @@ export default function TimelineView() {
                   </div>
                 )}
                 {/* Issue dots */}
-                {closedIssues.map((issue) => (
+                {timelineShowIssues && closedIssues.map((issue) => (
                   <IssueDot
                     key={issue.number}
                     issue={issue}
@@ -391,7 +403,7 @@ export default function TimelineView() {
                     onClick={() => setSelectedIssue(issue)}
                   />
                 ))}
-                {openIssues.map((issue, idx) => (
+                {timelineShowIssues && openIssues.map((issue, idx) => (
                   <IssueDot
                     key={issue.number}
                     issue={issue}
@@ -423,7 +435,7 @@ export default function TimelineView() {
               {todayX !== null && (
                 <div className="absolute top-0 bottom-0 w-px bg-red-200 pointer-events-none" style={{ left: todayX }} />
               )}
-              {noWaveIssues.map((issue) => (
+              {timelineShowIssues && noWaveIssues.map((issue) => (
                 <IssueDot
                   key={issue.number}
                   issue={issue}

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -161,6 +161,7 @@ export default function TimelineView() {
   const tw = TICK_WIDTH[g];
 
   const [selectedIssue, setSelectedIssue] = useState<GitHubIssue | null>(null);
+  const [savingWaves, setSavingWaves] = useState<Set<number>>(new Set());
   const [localDates, setLocalDates] = useState<Record<number, { start: string; end: string }>>({});
   const localDatesRef = useRef<Record<number, { start: string; end: string }>>({});
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -252,19 +253,20 @@ export default function TimelineView() {
 
     const onUp = () => {
       const drag = dragRef.current;
-      if (drag) {
-        const entry = localDatesRef.current[drag.milestoneNumber];
-        if (entry) {
-          setWaveDate(drag.milestoneNumber, entry.start, entry.end);
-          const rest = { ...localDatesRef.current };
-          delete rest[drag.milestoneNumber];
-          localDatesRef.current = rest;
-          setLocalDates(rest);
-        }
-      }
       dragRef.current = null;
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
+      if (!drag) return;
+      const entry = localDatesRef.current[drag.milestoneNumber];
+      const rest = { ...localDatesRef.current };
+      delete rest[drag.milestoneNumber];
+      localDatesRef.current = rest;
+      setLocalDates(rest);
+      if (!entry) return;
+      setSavingWaves((prev) => new Set(prev).add(drag.milestoneNumber));
+      setWaveDate(drag.milestoneNumber, entry.start, entry.end).finally(() => {
+        setSavingWaves((prev) => { const next = new Set(prev); next.delete(drag.milestoneNumber); return next; });
+      });
     };
 
     document.addEventListener('mousemove', onMove);
@@ -421,6 +423,15 @@ export default function TimelineView() {
                     >
                       {m.title}
                     </div>
+                    {/* Saving spinner */}
+                    {savingWaves.has(m.number) && (
+                      <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none">
+                        <svg className="animate-spin w-3 h-3 text-purple-500" viewBox="0 0 24 24" fill="none">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                      </div>
+                    )}
                     {/* Right resize handle */}
                     <div
                       className="absolute right-0 top-0 w-3 h-full cursor-e-resize rounded-r-md hover:bg-purple-400/30 z-10"

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -6,7 +6,7 @@ type Granularity = 'day' | 'week' | 'quarter' | 'year';
 
 const TICK_WIDTH: Record<Granularity, number> = { day: 44, week: 80, quarter: 110, year: 90 };
 const LABEL_WIDTH = 160;
-const ROW_HEIGHT = 64;
+const ROW_HEIGHT = 72;
 const HEADER_HEIGHT = 40;
 
 const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -247,7 +247,7 @@ export default function TimelineView() {
           return (
             <div key={m.number} className="flex border-b border-gray-100" style={{ height: ROW_HEIGHT }}>
               <div
-                className="sticky left-0 z-10 bg-white border-r border-gray-200 shrink-0 flex items-center px-3 text-sm font-medium text-purple-900"
+                className="sticky left-0 z-10 bg-white border-r border-gray-200 shrink-0 flex items-start pt-2 px-3 text-sm font-medium text-purple-900"
                 style={{ width: LABEL_WIDTH }}
               >
                 <span className="truncate">{m.title}</span>
@@ -272,7 +272,7 @@ export default function TimelineView() {
                 {barWidth > 0 && (
                   <div
                     className="absolute rounded-md bg-purple-200 select-none"
-                    style={{ left: startX, width: barWidth, top: 14, height: 36 }}
+                    style={{ left: startX, width: barWidth, top: 6, height: 24 }}
                   >
                     {/* Left resize handle */}
                     <div
@@ -280,7 +280,7 @@ export default function TimelineView() {
                       onMouseDown={(e) => startEdgeDrag(e, m, 'start')}
                     />
                     {/* Label */}
-                    <div className="absolute inset-0 flex items-center justify-center text-xs text-purple-700 font-medium pointer-events-none overflow-hidden px-3">
+                    <div className="absolute inset-0 flex items-center justify-start text-xs text-purple-700 font-medium pointer-events-none overflow-hidden px-3">
                       {m.title}
                     </div>
                     {/* Right resize handle */}
@@ -295,7 +295,7 @@ export default function TimelineView() {
                   <div
                     key={issue.number}
                     className="absolute w-2.5 h-2.5 rounded-full bg-purple-500 -translate-x-[5px] cursor-pointer hover:bg-purple-700 transition-colors"
-                    style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT / 2 - 5 }}
+                    style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT - 22 }}
                     title={`#${issue.number}: ${issue.title}`}
                   />
                 ))}
@@ -324,7 +324,7 @@ export default function TimelineView() {
                 <div
                   key={issue.number}
                   className="absolute w-2.5 h-2.5 rounded-full bg-gray-400 -translate-x-[5px] cursor-pointer hover:bg-gray-600 transition-colors"
-                  style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT / 2 - 5 }}
+                  style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT - 22 }}
                   title={`#${issue.number}: ${issue.title}`}
                 />
               ))}

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -214,6 +214,7 @@ export default function TimelineView() {
   const xToD = (x: number) => xToDate(x, ticks, tw);
 
   useEffect(() => {
+    if (dragRef.current) return;
     const container = scrollContainerRef.current;
     if (!container || !ticks.length) return;
     const todayXValue = dateToX(new Date(), ticks, tw);

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -82,21 +82,18 @@ function toISODate(d: Date): string {
 }
 
 function fallbackDates(m: GitHubMilestone, issues: GitHubIssue[]): { start: string; end: string } {
-  const closed = issues.filter(
-    (i) => i.milestone?.number === m.number && i.state === 'closed' && i.closed_at,
+  const waveIssues = issues.filter((i) => i.milestone?.number === m.number);
+  const oldest = waveIssues.reduce<GitHubIssue | null>(
+    (a, b) => !a || b.created_at < a.created_at ? b : a, null,
   );
+  const start = oldest ? toISODate(new Date(oldest.created_at)) : toISODate(new Date());
+  if (m.due_on) return { start, end: toISODate(new Date(m.due_on)) };
+  const closed = waveIssues.filter((i) => i.state === 'closed' && i.closed_at);
   if (closed.length > 0) {
-    const ms = closed.map((i) => new Date(i.closed_at!).getTime());
-    const s = new Date(Math.min(...ms));
-    const e = new Date(Math.max(...ms) + 7 * 86400_000);
-    return { start: toISODate(s), end: toISODate(e) };
+    const maxMs = Math.max(...closed.map((i) => new Date(i.closed_at!).getTime()));
+    return { start, end: toISODate(new Date(maxMs + 7 * 86400_000)) };
   }
-  if (m.due_on) {
-    const due = new Date(m.due_on);
-    return { start: toISODate(new Date(due.getTime() - 30 * 86400_000)), end: toISODate(due) };
-  }
-  const now = new Date();
-  return { start: toISODate(now), end: toISODate(new Date(now.getTime() + 30 * 86400_000)) };
+  return { start, end: toISODate(new Date(new Date(start).getTime() + 30 * 86400_000)) };
 }
 
 function sortedMilestones(milestones: GitHubMilestone[], order: number[]): GitHubMilestone[] {

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -1,0 +1,343 @@
+import { useMemo, useRef, useState } from 'react';
+import { useAppStore } from '../store/appStore';
+import type { GitHubIssue, GitHubMilestone } from '../types';
+
+type Granularity = 'day' | 'week' | 'quarter' | 'year';
+
+const TICK_WIDTH: Record<Granularity, number> = { day: 44, week: 80, quarter: 110, year: 90 };
+const LABEL_WIDTH = 160;
+const ROW_HEIGHT = 64;
+const HEADER_HEIGHT = 40;
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function floorToGranularity(d: Date, g: Granularity): Date {
+  switch (g) {
+    case 'day':
+      return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    case 'week': {
+      const day = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+      const dow = day.getDay();
+      day.setDate(day.getDate() - (dow === 0 ? 6 : dow - 1));
+      return day;
+    }
+    case 'quarter':
+      return new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
+    case 'year':
+      return new Date(d.getFullYear(), 0, 1);
+  }
+}
+
+function addTick(d: Date, g: Granularity): Date {
+  const r = new Date(d);
+  if (g === 'day') r.setDate(r.getDate() + 1);
+  else if (g === 'week') r.setDate(r.getDate() + 7);
+  else if (g === 'quarter') r.setMonth(r.getMonth() + 3);
+  else r.setFullYear(r.getFullYear() + 1);
+  return r;
+}
+
+function tickLabel(d: Date, g: Granularity): string {
+  if (g === 'day') return `${MONTHS[d.getMonth()]} ${d.getDate()}`;
+  if (g === 'week') return `${MONTHS[d.getMonth()]} ${d.getDate()}`;
+  if (g === 'quarter') return `Q${Math.floor(d.getMonth() / 3) + 1} '${String(d.getFullYear()).slice(-2)}`;
+  return String(d.getFullYear());
+}
+
+function generateTicks(start: Date, end: Date, g: Granularity): Date[] {
+  const ticks: Date[] = [];
+  let cur = new Date(start);
+  while (cur <= end) {
+    ticks.push(new Date(cur));
+    cur = addTick(cur, g);
+  }
+  return ticks;
+}
+
+function dateToX(date: Date, ticks: Date[], tw: number): number {
+  if (ticks.length === 0) return 0;
+  const ms = date.getTime();
+  for (let i = 0; i < ticks.length - 1; i++) {
+    const t0 = ticks[i].getTime();
+    const t1 = ticks[i + 1].getTime();
+    if (ms >= t0 && ms < t1) return (i + (ms - t0) / (t1 - t0)) * tw;
+  }
+  if (ms < ticks[0].getTime()) return 0;
+  return ticks.length * tw;
+}
+
+function xToDate(x: number, ticks: Date[], tw: number): Date {
+  if (ticks.length === 0) return new Date();
+  const idx = x / tw;
+  const i = Math.floor(idx);
+  const frac = idx - i;
+  if (i < 0) return ticks[0];
+  if (i >= ticks.length - 1) return ticks[ticks.length - 1];
+  return new Date(ticks[i].getTime() + frac * (ticks[i + 1].getTime() - ticks[i].getTime()));
+}
+
+function toISODate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function fallbackDates(m: GitHubMilestone, issues: GitHubIssue[]): { start: string; end: string } {
+  const closed = issues.filter(
+    (i) => i.milestone?.number === m.number && i.state === 'closed' && i.closed_at,
+  );
+  if (closed.length > 0) {
+    const ms = closed.map((i) => new Date(i.closed_at!).getTime());
+    const s = new Date(Math.min(...ms));
+    const e = new Date(Math.max(...ms) + 7 * 86400_000);
+    return { start: toISODate(s), end: toISODate(e) };
+  }
+  if (m.due_on) {
+    const due = new Date(m.due_on);
+    return { start: toISODate(new Date(due.getTime() - 30 * 86400_000)), end: toISODate(due) };
+  }
+  const now = new Date();
+  return { start: toISODate(now), end: toISODate(new Date(now.getTime() + 30 * 86400_000)) };
+}
+
+function sortedMilestones(milestones: GitHubMilestone[], order: number[]): GitHubMilestone[] {
+  return [...milestones].sort((a, b) => {
+    const ai = order.indexOf(a.number), bi = order.indexOf(b.number);
+    if (ai === -1 && bi === -1) return 0;
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}
+
+export default function TimelineView() {
+  const { milestones, issues, layout, setWaveDate, timelineGranularity } = useAppStore();
+
+  const g = timelineGranularity;
+  const tw = TICK_WIDTH[g];
+
+  const [localDates, setLocalDates] = useState<Record<number, { start: string; end: string }>>({});
+  const localDatesRef = useRef<Record<number, { start: string; end: string }>>({});
+  const dragRef = useRef<{
+    milestoneNumber: number;
+    edge: 'start' | 'end';
+    startMouseX: number;
+    origX: number;
+  } | null>(null);
+
+  const ordered = useMemo(
+    () => sortedMilestones(milestones, layout.milestoneOrder ?? []),
+    [milestones, layout.milestoneOrder],
+  );
+
+  const effectiveDates = useMemo(() => {
+    const map: Record<number, { start: string; end: string }> = {};
+    for (const m of ordered) {
+      map[m.number] =
+        localDates[m.number] ??
+        layout.waveDates?.[m.number] ??
+        fallbackDates(m, issues);
+    }
+    return map;
+  }, [ordered, localDates, layout.waveDates, issues]);
+
+  const { ticks, totalWidth } = useMemo(() => {
+    const allMs: number[] = [];
+    for (const m of ordered) {
+      const d = effectiveDates[m.number];
+      if (d) { allMs.push(new Date(d.start).getTime(), new Date(d.end).getTime()); }
+    }
+    issues.filter((i) => i.state === 'closed' && i.closed_at).forEach((i) =>
+      allMs.push(new Date(i.closed_at!).getTime()),
+    );
+    const now = Date.now();
+    const minMs = allMs.length ? Math.min(...allMs) : now - 30 * 86400_000;
+    const maxMs = allMs.length ? Math.max(...allMs) : now + 30 * 86400_000;
+    const rangeStart = floorToGranularity(new Date(minMs), g);
+    const padEnd = addTick(floorToGranularity(new Date(maxMs), g), g);
+    const t = generateTicks(rangeStart, padEnd, g);
+    return { ticks: t, totalWidth: t.length * tw };
+  }, [ordered, effectiveDates, issues, g, tw]);
+
+  const dToX = (d: Date) => dateToX(d, ticks, tw);
+  const xToD = (x: number) => xToDate(x, ticks, tw);
+
+  function startEdgeDrag(e: React.MouseEvent, m: GitHubMilestone, edge: 'start' | 'end') {
+    e.preventDefault();
+    const dates = effectiveDates[m.number];
+    const origDate = edge === 'start' ? new Date(dates.start) : new Date(dates.end);
+    dragRef.current = { milestoneNumber: m.number, edge, startMouseX: e.clientX, origX: dToX(origDate) };
+
+    const onMove = (ev: MouseEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const newX = Math.max(0, drag.origX + (ev.clientX - drag.startMouseX));
+      const dateStr = toISODate(xToD(newX));
+      const curr = localDatesRef.current[drag.milestoneNumber] ?? effectiveDates[drag.milestoneNumber];
+      const next = drag.edge === 'start'
+        ? { start: dateStr, end: curr.end }
+        : { start: curr.start, end: dateStr };
+      localDatesRef.current = { ...localDatesRef.current, [drag.milestoneNumber]: next };
+      setLocalDates({ ...localDatesRef.current });
+    };
+
+    const onUp = () => {
+      const drag = dragRef.current;
+      if (drag) {
+        const entry = localDatesRef.current[drag.milestoneNumber];
+        if (entry) {
+          setWaveDate(drag.milestoneNumber, entry.start, entry.end);
+          const rest = { ...localDatesRef.current };
+          delete rest[drag.milestoneNumber];
+          localDatesRef.current = rest;
+          setLocalDates(rest);
+        }
+      }
+      dragRef.current = null;
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }
+
+  const noWaveIssues = issues.filter((i) => !i.milestone && i.state === 'closed' && i.closed_at);
+  const todayX = ticks.length ? dToX(new Date()) : null;
+
+  return (
+    <div className="flex-1 overflow-auto h-full" style={{ minWidth: 0 }}>
+      <div style={{ minWidth: LABEL_WIDTH + totalWidth }}>
+
+        {/* Time axis header */}
+        <div
+          className="sticky top-0 z-20 bg-white border-b border-gray-200 flex"
+          style={{ height: HEADER_HEIGHT }}
+        >
+          <div
+            className="sticky left-0 z-30 bg-white border-r border-gray-200 shrink-0"
+            style={{ width: LABEL_WIDTH }}
+          />
+          <div className="relative shrink-0" style={{ width: totalWidth }}>
+            {ticks.map((tick, i) => (
+              <div
+                key={i}
+                className="absolute top-0 h-full border-r border-gray-100 flex items-center justify-center text-xs text-gray-400 select-none"
+                style={{ left: i * tw, width: tw }}
+              >
+                {tickLabel(tick, g)}
+              </div>
+            ))}
+            {todayX !== null && (
+              <div
+                className="absolute top-0 bottom-0 w-px bg-red-300 pointer-events-none"
+                style={{ left: todayX }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Wave rows */}
+        {ordered.map((m) => {
+          const dates = effectiveDates[m.number];
+          const startX = dToX(new Date(dates.start));
+          const endX = dToX(new Date(dates.end));
+          const barWidth = Math.max(0, endX - startX);
+          const waveIssues = issues.filter(
+            (i) => i.milestone?.number === m.number && i.state === 'closed' && i.closed_at,
+          );
+          return (
+            <div key={m.number} className="flex border-b border-gray-100" style={{ height: ROW_HEIGHT }}>
+              <div
+                className="sticky left-0 z-10 bg-white border-r border-gray-200 shrink-0 flex items-center px-3 text-sm font-medium text-purple-900"
+                style={{ width: LABEL_WIDTH }}
+              >
+                <span className="truncate">{m.title}</span>
+              </div>
+              <div className="relative shrink-0" style={{ width: totalWidth }}>
+                {/* Grid lines */}
+                {ticks.map((_, i) => (
+                  <div
+                    key={i}
+                    className="absolute top-0 bottom-0 border-r border-gray-50"
+                    style={{ left: i * tw }}
+                  />
+                ))}
+                {/* Today line */}
+                {todayX !== null && (
+                  <div
+                    className="absolute top-0 bottom-0 w-px bg-red-200 pointer-events-none"
+                    style={{ left: todayX }}
+                  />
+                )}
+                {/* Wave bar */}
+                {barWidth > 0 && (
+                  <div
+                    className="absolute rounded-md bg-purple-200 select-none"
+                    style={{ left: startX, width: barWidth, top: 14, height: 36 }}
+                  >
+                    {/* Left resize handle */}
+                    <div
+                      className="absolute left-0 top-0 w-3 h-full cursor-w-resize rounded-l-md hover:bg-purple-400/30 z-10"
+                      onMouseDown={(e) => startEdgeDrag(e, m, 'start')}
+                    />
+                    {/* Label */}
+                    <div className="absolute inset-0 flex items-center justify-center text-xs text-purple-700 font-medium pointer-events-none overflow-hidden px-3">
+                      {m.title}
+                    </div>
+                    {/* Right resize handle */}
+                    <div
+                      className="absolute right-0 top-0 w-3 h-full cursor-e-resize rounded-r-md hover:bg-purple-400/30 z-10"
+                      onMouseDown={(e) => startEdgeDrag(e, m, 'end')}
+                    />
+                  </div>
+                )}
+                {/* Closed issue dots */}
+                {waveIssues.map((issue) => (
+                  <div
+                    key={issue.number}
+                    className="absolute w-2.5 h-2.5 rounded-full bg-purple-500 -translate-x-[5px] cursor-pointer hover:bg-purple-700 transition-colors"
+                    style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT / 2 - 5 }}
+                    title={`#${issue.number}: ${issue.title}`}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* No Wave row */}
+        {noWaveIssues.length > 0 && (
+          <div className="flex border-b border-gray-100" style={{ height: ROW_HEIGHT }}>
+            <div
+              className="sticky left-0 z-10 bg-gray-50 border-r border-gray-200 shrink-0 flex items-center px-3 text-sm italic text-gray-400"
+              style={{ width: LABEL_WIDTH }}
+            >
+              No Wave
+            </div>
+            <div className="relative shrink-0" style={{ width: totalWidth }}>
+              {ticks.map((_, i) => (
+                <div key={i} className="absolute top-0 bottom-0 border-r border-gray-50" style={{ left: i * tw }} />
+              ))}
+              {todayX !== null && (
+                <div className="absolute top-0 bottom-0 w-px bg-red-200 pointer-events-none" style={{ left: todayX }} />
+              )}
+              {noWaveIssues.map((issue) => (
+                <div
+                  key={issue.number}
+                  className="absolute w-2.5 h-2.5 rounded-full bg-gray-400 -translate-x-[5px] cursor-pointer hover:bg-gray-600 transition-colors"
+                  style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT / 2 - 5 }}
+                  title={`#${issue.number}: ${issue.title}`}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {ordered.length === 0 && noWaveIssues.length === 0 && (
+          <div className="flex items-center justify-center h-48 text-gray-400 text-sm">
+            No waves or closed issues to display.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -108,16 +108,34 @@ function sortedMilestones(milestones: GitHubMilestone[], order: number[]): GitHu
   });
 }
 
-type IssueStatus = 'closed' | 'in-progress' | 'todo';
+const GITHUB_COLOR_HEX: Record<string, string> = {
+  GREEN: '#4ade80', YELLOW: '#facc15', ORANGE: '#fb923c', RED: '#f87171',
+  BLUE: '#60a5fa', PURPLE: '#c084fc', PINK: '#f472b6', GRAY: '#9ca3af',
+};
+const CLOSED_COLOR = '#c084fc';
+const NO_STATUS_COLOR = '#e5e7eb';
 
-function issueStatus(issue: GitHubIssue, kanbanStatuses: Record<number, string>): IssueStatus {
-  if (issue.state === 'closed') return 'closed';
-  const raw = (kanbanStatuses[issue.number] ?? issue.labels.find((l) => l.name.startsWith('s_'))?.name.slice(2) ?? '').toLowerCase();
-  return raw === 'to do' || raw === 'todo' || raw === '' ? 'todo' : 'in-progress';
+function githubColorToHex(name: string): string {
+  return GITHUB_COLOR_HEX[name.toUpperCase()] ?? NO_STATUS_COLOR;
+}
+
+function statusSortKey(name: string): number {
+  const n = name.toLowerCase().trim();
+  if (n === 'to do' || n === 'todo') return 0;
+  if (n.includes('progress')) return 1;
+  if (n === 'done') return 2;
+  return 3;
+}
+
+function issueStatusColor(issue: GitHubIssue, kanbanStatuses: Record<number, string>, kanbanStatusColors: Record<string, string>): string {
+  if (issue.state === 'closed') return CLOSED_COLOR;
+  const status = kanbanStatuses[issue.number] ?? issue.labels.find((l) => l.name.startsWith('s_'))?.name.slice(2);
+  if (!status) return NO_STATUS_COLOR;
+  return githubColorToHex(kanbanStatusColors[status] ?? '');
 }
 
 export default function TimelineView() {
-  const { milestones, issues, layout, setWaveDate, timelineGranularity, setTimelineGranularity, kanbanIssueStatuses } = useAppStore();
+  const { milestones, issues, layout, setWaveDate, timelineGranularity, setTimelineGranularity, kanbanIssueStatuses, kanbanStatusColumns, kanbanStatusColors } = useAppStore();
 
   const g = timelineGranularity;
   const tw = TICK_WIDTH[g];
@@ -228,18 +246,21 @@ export default function TimelineView() {
             </button>
           ))}
         </div>
-        <div className="flex items-center gap-3 text-xs text-gray-500">
+        <div className="flex items-center gap-3 text-xs text-gray-500 flex-wrap">
+          {[...kanbanStatusColumns]
+            .sort((a, b) => statusSortKey(a) - statusSortKey(b))
+            .map((status) => (
+              <span key={status} className="flex items-center gap-1.5">
+                <span
+                  className="inline-block w-3 h-3 rounded-full"
+                  style={{ background: githubColorToHex(kanbanStatusColors[status] ?? '') }}
+                />
+                {status}
+              </span>
+            ))}
           <span className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded-full bg-purple-500" />
+            <span className="inline-block w-3 h-3 rounded-full" style={{ background: CLOSED_COLOR }} />
             Closed
-          </span>
-          <span className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded-full bg-orange-400" />
-            In Progress
-          </span>
-          <span className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded-full bg-white border border-gray-400" />
-            To Do
           </span>
         </div>
       </div>
@@ -334,31 +355,23 @@ export default function TimelineView() {
                     />
                   </div>
                 )}
-                {/* Closed issue dots */}
+                {/* Issue dots */}
                 {closedIssues.map((issue) => (
                   <div
                     key={issue.number}
-                    className="absolute w-2.5 h-2.5 rounded-full bg-purple-500 -translate-x-[5px] cursor-pointer hover:bg-purple-700 transition-colors"
-                    style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT - 22 }}
+                    className="absolute w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer"
+                    style={{ left: dToX(new Date(issue.closed_at!)), top: ROW_HEIGHT - 22, background: CLOSED_COLOR }}
                     title={`#${issue.number}: ${issue.title}`}
                   />
                 ))}
-                {/* In-progress / todo dots at today (clamped to wave range) */}
-                {openIssues.map((issue, idx) => {
-                  const status = issueStatus(issue, kanbanIssueStatuses);
-                  return (
-                    <div
-                      key={issue.number}
-                      className={`absolute w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer transition-colors border ${
-                        status === 'in-progress'
-                          ? 'bg-orange-400 border-orange-500 hover:bg-orange-600'
-                          : 'bg-white border-gray-400 hover:border-gray-600'
-                      }`}
-                      style={{ left: openDotX + idx * 2, top: ROW_HEIGHT - 22 }}
-                      title={`#${issue.number}: ${issue.title} (${status})`}
-                    />
-                  );
-                })}
+                {openIssues.map((issue, idx) => (
+                  <div
+                    key={issue.number}
+                    className="absolute w-2.5 h-2.5 rounded-full -translate-x-[5px] cursor-pointer"
+                    style={{ left: openDotX + idx * 2, top: ROW_HEIGHT - 22, background: issueStatusColor(issue, kanbanIssueStatuses, kanbanStatusColors) }}
+                    title={`#${issue.number}: ${issue.title}`}
+                  />
+                ))}
               </div>
             </div>
           );

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -214,7 +214,6 @@ export default function TimelineView() {
   const xToD = (x: number) => xToDate(x, ticks, tw);
 
   useEffect(() => {
-    if (dragRef.current) return;
     const container = scrollContainerRef.current;
     if (!container || !ticks.length) return;
     const todayXValue = dateToX(new Date(), ticks, tw);
@@ -222,7 +221,7 @@ export default function TimelineView() {
     const targetLeft = Math.max(0, LABEL_WIDTH + todayXValue - containerWidth / 2);
     container.scrollTo({ left: targetLeft, behavior: isFirstScroll.current ? 'instant' : 'smooth' });
     isFirstScroll.current = false;
-  }, [ticks, tw]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [g]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function startEdgeDrag(e: React.MouseEvent, m: GitHubMilestone, edge: 'start' | 'end') {
     e.preventDefault();

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -167,9 +167,10 @@ export default function TimelineView() {
   const isFirstScroll = useRef(true);
   const dragRef = useRef<{
     milestoneNumber: number;
-    edge: 'start' | 'end';
+    edge: 'start' | 'end' | 'move';
     startMouseX: number;
-    origX: number;
+    origStartX: number;
+    origEndX: number;
   } | null>(null);
 
   const ordered = useMemo(
@@ -220,21 +221,31 @@ export default function TimelineView() {
     isFirstScroll.current = false;
   }, [g]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  function startEdgeDrag(e: React.MouseEvent, m: GitHubMilestone, edge: 'start' | 'end') {
+  function startEdgeDrag(e: React.MouseEvent, m: GitHubMilestone, edge: 'start' | 'end' | 'move') {
     e.preventDefault();
     const dates = effectiveDates[m.number];
-    const origDate = edge === 'start' ? new Date(dates.start) : new Date(dates.end);
-    dragRef.current = { milestoneNumber: m.number, edge, startMouseX: e.clientX, origX: dToX(origDate) };
+    dragRef.current = {
+      milestoneNumber: m.number, edge, startMouseX: e.clientX,
+      origStartX: dToX(new Date(dates.start)),
+      origEndX: dToX(new Date(dates.end)),
+    };
 
     const onMove = (ev: MouseEvent) => {
       const drag = dragRef.current;
       if (!drag) return;
-      const newX = Math.max(0, drag.origX + (ev.clientX - drag.startMouseX));
-      const dateStr = toISODate(xToD(newX));
-      const curr = localDatesRef.current[drag.milestoneNumber] ?? effectiveDates[drag.milestoneNumber];
-      const next = drag.edge === 'start'
-        ? { start: dateStr, end: curr.end }
-        : { start: curr.start, end: dateStr };
+      const delta = ev.clientX - drag.startMouseX;
+      let next: { start: string; end: string };
+      if (drag.edge === 'move') {
+        next = {
+          start: toISODate(xToD(Math.max(0, drag.origStartX + delta))),
+          end: toISODate(xToD(Math.max(0, drag.origEndX + delta))),
+        };
+      } else {
+        const newX = Math.max(0, (drag.edge === 'start' ? drag.origStartX : drag.origEndX) + delta);
+        const dateStr = toISODate(xToD(newX));
+        const curr = localDatesRef.current[drag.milestoneNumber] ?? effectiveDates[drag.milestoneNumber];
+        next = drag.edge === 'start' ? { start: dateStr, end: curr.end } : { start: curr.start, end: dateStr };
+      }
       localDatesRef.current = { ...localDatesRef.current, [drag.milestoneNumber]: next };
       setLocalDates({ ...localDatesRef.current });
     };
@@ -403,8 +414,11 @@ export default function TimelineView() {
                       className="absolute left-0 top-0 w-3 h-full cursor-w-resize rounded-l-md hover:bg-purple-400/30 z-10"
                       onMouseDown={(e) => startEdgeDrag(e, m, 'start')}
                     />
-                    {/* Label */}
-                    <div className="absolute inset-0 flex items-center justify-start text-xs text-purple-700 font-medium pointer-events-none overflow-hidden px-3">
+                    {/* Label / move handle */}
+                    <div
+                      className="absolute inset-0 flex items-center justify-start text-xs text-purple-700 font-medium overflow-hidden px-3 cursor-grab active:cursor-grabbing"
+                      onMouseDown={(e) => startEdgeDrag(e, m, 'move')}
+                    >
                       {m.title}
                     </div>
                     {/* Right resize handle */}

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -67,6 +67,7 @@ function SidebarItem({
       </div>
       {waveDates && (
         <span className="text-xs text-purple-500 mt-0.5">
+          <span className="text-gray-400 mr-1">Timeline</span>
           {fmtDate(waveDates.start)} – {fmtDate(waveDates.end)}
         </span>
       )}
@@ -338,10 +339,17 @@ export default function WavesView() {
                     const dates = resolveDates(selected, milestoneIssues, layout.waveDates?.[selected.number]);
                     return dates ? (
                       <p className="text-xs text-purple-500 mb-1">
+                        <span className="text-gray-400 mr-1">Timeline</span>
                         {fmtDate(dates.start)} – {fmtDate(dates.end)}
                       </p>
                     ) : null;
                   })()}
+                  {selected.due_on && (
+                    <p className="text-xs text-gray-400 mb-2">
+                      <span className="mr-1">Due</span>
+                      {new Date(selected.due_on).toLocaleDateString()}
+                    </p>
+                  )}
                   <a
                     href={`https://github.com/${owner}/${repo}/milestone/${selected.number}`}
                     target="_blank"

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -24,16 +24,18 @@ function resolveDates(
   waveDates?: { start: string; end: string },
 ): { start: string; end: string } | null {
   if (waveDates) return waveDates;
-  const closed = issues.filter((i) => i.milestone?.number === m.number && i.state === 'closed' && i.closed_at);
+  if (issues.length === 0 && !m.due_on) return null;
+  const oldest = issues.reduce<GitHubIssue | null>(
+    (a, b) => !a || b.created_at < a.created_at ? b : a, null,
+  );
+  const start = oldest ? toISODate(new Date(oldest.created_at)) : toISODate(new Date());
+  if (m.due_on) return { start, end: toISODate(new Date(m.due_on)) };
+  const closed = issues.filter((i) => i.state === 'closed' && i.closed_at);
   if (closed.length > 0) {
-    const ms = closed.map((i) => new Date(i.closed_at!).getTime());
-    return { start: toISODate(new Date(Math.min(...ms))), end: toISODate(new Date(Math.max(...ms) + 7 * 86400_000)) };
+    const maxMs = Math.max(...closed.map((i) => new Date(i.closed_at!).getTime()));
+    return { start, end: toISODate(new Date(maxMs + 7 * 86400_000)) };
   }
-  if (m.due_on) {
-    const due = new Date(m.due_on);
-    return { start: toISODate(new Date(due.getTime() - 30 * 86400_000)), end: toISODate(due) };
-  }
-  return null;
+  return { start, end: toISODate(new Date(new Date(start).getTime() + 30 * 86400_000)) };
 }
 
 function SidebarItem({

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
-import type { GitHubMilestone } from '../types';
+import type { GitHubIssue, GitHubMilestone } from '../types';
 import IssueCard from './IssueCard';
 
 const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -12,6 +12,28 @@ function fmtDate(iso: string): string {
   return year === now
     ? `${MONTHS[d.getMonth()]} ${d.getDate()}`
     : `${MONTHS[d.getMonth()]} ${d.getDate()} '${String(year).slice(-2)}`;
+}
+
+function toISODate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function resolveDates(
+  m: GitHubMilestone,
+  issues: GitHubIssue[],
+  waveDates?: { start: string; end: string },
+): { start: string; end: string } | null {
+  if (waveDates) return waveDates;
+  const closed = issues.filter((i) => i.milestone?.number === m.number && i.state === 'closed' && i.closed_at);
+  if (closed.length > 0) {
+    const ms = closed.map((i) => new Date(i.closed_at!).getTime());
+    return { start: toISODate(new Date(Math.min(...ms))), end: toISODate(new Date(Math.max(...ms) + 7 * 86400_000)) };
+  }
+  if (m.due_on) {
+    const due = new Date(m.due_on);
+    return { start: toISODate(new Date(due.getTime() - 30 * 86400_000)), end: toISODate(due) };
+  }
+  return null;
 }
 
 function SidebarItem({
@@ -188,7 +210,7 @@ export default function WavesView() {
                 closedCount={issueCounts[m.number]?.closed ?? 0}
                 owner={owner}
                 repo={repo}
-                waveDates={layout.waveDates?.[m.number]}
+                waveDates={resolveDates(m, issues, layout.waveDates?.[m.number]) ?? undefined}
               />
             ))
           )}
@@ -312,16 +334,14 @@ export default function WavesView() {
                   {selected.description && (
                     <p className="text-sm text-gray-500 mb-2">{selected.description}</p>
                   )}
-                  {layout.waveDates?.[selected.number] && (
-                    <p className="text-xs text-purple-500 mb-1">
-                      {fmtDate(layout.waveDates[selected.number].start)} – {fmtDate(layout.waveDates[selected.number].end)}
-                    </p>
-                  )}
-                  {selected.due_on && (
-                    <p className="text-xs text-gray-400 mb-2">
-                      Due {new Date(selected.due_on).toLocaleDateString()}
-                    </p>
-                  )}
+                  {(() => {
+                    const dates = resolveDates(selected, milestoneIssues, layout.waveDates?.[selected.number]);
+                    return dates ? (
+                      <p className="text-xs text-purple-500 mb-1">
+                        {fmtDate(dates.start)} – {fmtDate(dates.end)}
+                      </p>
+                    ) : null;
+                  })()}
                   <a
                     href={`https://github.com/${owner}/${repo}/milestone/${selected.number}`}
                     target="_blank"

--- a/src/components/WavesView.tsx
+++ b/src/components/WavesView.tsx
@@ -3,6 +3,17 @@ import { useAppStore } from '../store/appStore';
 import type { GitHubMilestone } from '../types';
 import IssueCard from './IssueCard';
 
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  const year = d.getFullYear();
+  const now = new Date().getFullYear();
+  return year === now
+    ? `${MONTHS[d.getMonth()]} ${d.getDate()}`
+    : `${MONTHS[d.getMonth()]} ${d.getDate()} '${String(year).slice(-2)}`;
+}
+
 function SidebarItem({
   milestone,
   selected,
@@ -11,6 +22,7 @@ function SidebarItem({
   closedCount,
   owner,
   repo,
+  waveDates,
 }: {
   milestone: GitHubMilestone;
   selected: boolean;
@@ -19,6 +31,7 @@ function SidebarItem({
   closedCount: number;
   owner: string;
   repo: string;
+  waveDates?: { start: string; end: string };
 }) {
   return (
     <div
@@ -30,6 +43,11 @@ function SidebarItem({
           {milestone.title}
         </span>
       </div>
+      {waveDates && (
+        <span className="text-xs text-purple-500 mt-0.5">
+          {fmtDate(waveDates.start)} – {fmtDate(waveDates.end)}
+        </span>
+      )}
       <div className="flex items-center gap-1.5 mt-0.5">
         <span className="text-xs text-green-600">{openCount} open</span>
         <span className="text-xs text-gray-300">·</span>
@@ -56,7 +74,7 @@ function SidebarItem({
 }
 
 export default function WavesView() {
-  const { milestones, issues, owner, repo, createMilestone, updateMilestone, deleteMilestone } = useAppStore();
+  const { milestones, issues, owner, repo, layout, createMilestone, updateMilestone, deleteMilestone } = useAppStore();
   const [selectedNumber, setSelectedNumber] = useState<number | null>(
     milestones.length > 0 ? milestones[0].number : null,
   );
@@ -170,6 +188,7 @@ export default function WavesView() {
                 closedCount={issueCounts[m.number]?.closed ?? 0}
                 owner={owner}
                 repo={repo}
+                waveDates={layout.waveDates?.[m.number]}
               />
             ))
           )}
@@ -292,6 +311,11 @@ export default function WavesView() {
                   {deleteError && <p className="text-xs text-red-600 mb-2">{deleteError}</p>}
                   {selected.description && (
                     <p className="text-sm text-gray-500 mb-2">{selected.description}</p>
+                  )}
+                  {layout.waveDates?.[selected.number] && (
+                    <p className="text-xs text-purple-500 mb-1">
+                      {fmtDate(layout.waveDates[selected.number].start)} – {fmtDate(layout.waveDates[selected.number].end)}
+                    </p>
                   )}
                   {selected.due_on && (
                     <p className="text-xs text-gray-400 mb-2">

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,6 +2,10 @@ import { initializeApp } from 'firebase/app';
 import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
 import type { StoryMapLayout } from '../types';
 
+export interface UserProfile {
+  timelineGranularity?: 'day' | 'week' | 'quarter' | 'year';
+}
+
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
@@ -34,4 +38,15 @@ export async function saveLayout(
 ): Promise<void> {
   const ref = doc(db, 'storyMaps', repoKey(owner, repo));
   await setDoc(ref, layout);
+}
+
+export async function loadUserProfile(owner: string): Promise<UserProfile | null> {
+  const ref = doc(db, 'userProfiles', owner);
+  const snap = await getDoc(ref);
+  return snap.exists() ? (snap.data() as UserProfile) : null;
+}
+
+export async function saveUserProfile(owner: string, profile: UserProfile): Promise<void> {
+  const ref = doc(db, 'userProfiles', owner);
+  await setDoc(ref, profile, { merge: true });
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -4,6 +4,7 @@ import type { StoryMapLayout } from '../types';
 
 export interface UserProfile {
   timelineGranularity?: 'day' | 'week' | 'quarter' | 'year';
+  timelineShowIssues?: boolean;
 }
 
 const firebaseConfig = {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -13,7 +13,8 @@ interface AppState {
   error: string | null;
   milestones: GitHubMilestone[];
   statusLabels: string[]; // values without prefix, e.g. ["Todo", "In Progress", "Done"]
-  view: 'grid' | 'kanban' | 'waves' | 'user-activities' | 'roadmap' | 'settings';
+  view: 'grid' | 'kanban' | 'waves' | 'user-activities' | 'roadmap' | 'timeline' | 'settings';
+  timelineGranularity: 'day' | 'week' | 'quarter' | 'year';
   showClosedIssues: boolean;
   projects: GitHubProject[];
   projectIssues: Record<string, number[]>; // project node_id → issue numbers
@@ -41,7 +42,9 @@ interface AppState {
   updateMilestone: (number: number, title: string, description: string) => Promise<void>;
   deleteMilestone: (number: number) => Promise<void>;
   addStatusLabel: (name: string) => Promise<void>;
-  setView: (view: 'grid' | 'kanban' | 'waves' | 'user-activities' | 'roadmap' | 'settings') => void;
+  setView: (view: 'grid' | 'kanban' | 'waves' | 'user-activities' | 'roadmap' | 'timeline' | 'settings') => void;
+  setTimelineGranularity: (g: 'day' | 'week' | 'quarter' | 'year') => void;
+  setWaveDate: (milestoneNumber: number, start: string, end: string) => Promise<void>;
   moveStory: (
     storyNumber: number,
     fromKey: string,
@@ -144,6 +147,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   milestones: [],
   statusLabels: [],
   view: 'grid',
+  timelineGranularity: 'week' as const,
   showClosedIssues: false,
   projects: [],
   projectIssues: {},
@@ -170,6 +174,18 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   setView: (view) => set({ view }),
+
+  setTimelineGranularity: (g) => set({ timelineGranularity: g }),
+
+  setWaveDate: async (milestoneNumber, start, end) => {
+    const { owner, repo, layout } = get();
+    const newLayout = {
+      ...layout,
+      waveDates: { ...(layout.waveDates ?? {}), [milestoneNumber]: { start, end } },
+    };
+    set({ layout: newLayout });
+    saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
+  },
 
   toggleShowClosedIssues: () => set((state) => ({ showClosedIssues: !state.showClosedIssues })),
 
@@ -295,6 +311,7 @@ export const useAppStore = create<AppState>((set, get) => ({
               : null,
             state: item.state as 'open' | 'closed',
             html_url: item.html_url,
+            closed_at: item.closed_at ?? null,
           } as GitHubIssue));
 
         allItems.push(...mapped);
@@ -389,6 +406,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       milestone: data.milestone ? { number: data.milestone.number, title: data.milestone.title, description: null, state: 'open', due_on: null } : null,
       state: 'open',
       html_url: data.html_url,
+      closed_at: null,
     };
 
     set({ issues: [...issues, newIssue] });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { Octokit } from '@octokit/rest';
 import type { GitHubIssue, GitHubMilestone, GitHubProject, StoryMapLayout } from '../types';
-import { loadLayout, saveLayout } from '../lib/firebase';
+import { loadLayout, saveLayout, loadUserProfile, saveUserProfile } from '../lib/firebase';
 
 interface AppState {
   token: string;
@@ -175,7 +175,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setView: (view) => set({ view }),
 
-  setTimelineGranularity: (g) => set({ timelineGranularity: g }),
+  setTimelineGranularity: (g) => {
+    set({ timelineGranularity: g });
+    const { owner } = get();
+    if (owner) saveUserProfile(owner, { timelineGranularity: g }).catch(() => {});
+  },
 
   setWaveDate: async (milestoneNumber, start, end) => {
     const { owner, repo, layout } = get();
@@ -321,10 +325,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       // Load or build layout — Firestore is optional; app works without it
       let savedLayout: StoryMapLayout | null = null;
+      let userProfile = null;
       try {
-        savedLayout = await loadLayout(owner, repo);
+        [savedLayout, userProfile] = await Promise.all([
+          loadLayout(owner, repo),
+          loadUserProfile(owner),
+        ]);
       } catch (firestoreErr) {
         console.warn('Firestore unavailable, building layout from issues', firestoreErr);
+      }
+      if (userProfile?.timelineGranularity) {
+        set({ timelineGranularity: userProfile.timelineGranularity });
       }
 
       let layout: StoryMapLayout;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -15,6 +15,7 @@ interface AppState {
   statusLabels: string[]; // values without prefix, e.g. ["Todo", "In Progress", "Done"]
   view: 'grid' | 'kanban' | 'waves' | 'user-activities' | 'roadmap' | 'timeline' | 'settings';
   timelineGranularity: 'day' | 'week' | 'quarter' | 'year';
+  timelineShowIssues: boolean;
   showClosedIssues: boolean;
   projects: GitHubProject[];
   projectIssues: Record<string, number[]>; // project node_id → issue numbers
@@ -44,6 +45,7 @@ interface AppState {
   addStatusLabel: (name: string) => Promise<void>;
   setView: (view: 'grid' | 'kanban' | 'waves' | 'user-activities' | 'roadmap' | 'timeline' | 'settings') => void;
   setTimelineGranularity: (g: 'day' | 'week' | 'quarter' | 'year') => void;
+  toggleTimelineShowIssues: () => void;
   setWaveDate: (milestoneNumber: number, start: string, end: string) => Promise<void>;
   moveStory: (
     storyNumber: number,
@@ -148,6 +150,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   statusLabels: [],
   view: 'grid',
   timelineGranularity: 'week' as const,
+  timelineShowIssues: true,
   showClosedIssues: false,
   projects: [],
   projectIssues: {},
@@ -179,6 +182,13 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ timelineGranularity: g });
     const { owner } = get();
     if (owner) saveUserProfile(owner, { timelineGranularity: g }).catch(() => {});
+  },
+
+  toggleTimelineShowIssues: () => {
+    const next = !get().timelineShowIssues;
+    set({ timelineShowIssues: next });
+    const { owner } = get();
+    if (owner) saveUserProfile(owner, { timelineShowIssues: next }).catch(() => {});
   },
 
   setWaveDate: async (milestoneNumber, start, end) => {
@@ -334,9 +344,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       } catch (firestoreErr) {
         console.warn('Firestore unavailable, building layout from issues', firestoreErr);
       }
-      if (userProfile?.timelineGranularity) {
-        set({ timelineGranularity: userProfile.timelineGranularity });
-      }
+      const profileUpdate: Partial<{ timelineGranularity: 'day' | 'week' | 'quarter' | 'year'; timelineShowIssues: boolean }> = {};
+      if (userProfile?.timelineGranularity) profileUpdate.timelineGranularity = userProfile.timelineGranularity;
+      if (userProfile?.timelineShowIssues !== undefined) profileUpdate.timelineShowIssues = userProfile.timelineShowIssues;
+      if (Object.keys(profileUpdate).length) set(profileUpdate);
 
       let layout: StoryMapLayout;
       if (!savedLayout) {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -336,6 +336,7 @@ export const useAppStore = create<AppState>((set, get) => ({
               : null,
             state: item.state as 'open' | 'closed',
             html_url: item.html_url,
+            created_at: item.created_at,
             closed_at: item.closed_at ?? null,
           } as GitHubIssue));
 
@@ -439,6 +440,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       milestone: data.milestone ? { number: data.milestone.number, title: data.milestone.title, description: null, state: 'open', due_on: null } : null,
       state: 'open',
       html_url: data.html_url,
+      created_at: data.created_at,
       closed_at: null,
     };
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -192,13 +192,24 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   setWaveDate: async (milestoneNumber, start, end) => {
-    const { owner, repo, layout } = get();
+    const { token, owner, repo, layout, milestones } = get();
     const newLayout = {
       ...layout,
       waveDates: { ...(layout.waveDates ?? {}), [milestoneNumber]: { start, end } },
     };
     set({ layout: newLayout });
-    saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
+    saveLayout(owner, repo, newLayout).catch(() => {});
+    if (token) {
+      try {
+        const octokit = new Octokit({ auth: token });
+        await octokit.rest.issues.updateMilestone({
+          owner, repo,
+          milestone_number: milestoneNumber,
+          due_on: `${end}T00:00:00Z`,
+        });
+        set({ milestones: milestones.map((m) => m.number === milestoneNumber ? { ...m, due_on: end } : m) });
+      } catch { /* silently ignore */ }
+    }
   },
 
   toggleShowClosedIssues: () => set((state) => ({ showClosedIssues: !state.showClosedIssues })),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface GitHubIssue {
   milestone: GitHubMilestone | null;
   state: 'open' | 'closed';
   html_url: string;
+  closed_at: string | null;
 }
 
 export interface StoryMapLayout {
@@ -34,6 +35,8 @@ export interface StoryMapLayout {
   milestoneOrder: number[];
   // key is project number as string, or "backlog" for unassigned
   storyOrder: Record<string, number[]>;
+  /** Wave (milestone) start/end dates for the Timeline view, keyed by milestone number. */
+  waveDates?: Record<number, { start: string; end: string }>;
 }
 
 export interface GitHubProject {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface GitHubIssue {
   milestone: GitHubMilestone | null;
   state: 'open' | 'closed';
   html_url: string;
+  created_at: string;
   closed_at: string | null;
 }
 


### PR DESCRIPTION
## Summary

- Adds a new **Timeline** tab to the toolbar, making waves (milestones) visible as draggable horizontal bars on a time axis alongside closed-issue delivery dots.
- Wave start/end dates are persisted to the existing Firestore `StoryMapLayout` document under a new `waveDates` field, so they survive page refreshes.
- Closed issues now expose their `closed_at` timestamp from the GitHub API, enabling accurate X-axis plotting of when each issue was delivered.

## Implementation notes

- **`GitHubIssue.closed_at`** (`string | null`) added to the type and mapped in `fetchIssues`. All existing `GitHubIssue` constructors (`createIssue`) set it to `null`.
- **`StoryMapLayout.waveDates`** (`Record<number, { start; end }>`) is optional so existing Firestore documents without it load cleanly.
- **Granularity** (`day / week / quarter / year`) is stored in the Zustand store (`timelineGranularity`) and exposed in a `<select>` in the header, visible only when the Timeline tab is active — exactly matching the pattern used by the Kanban wave filter.
- **Wave bar drag**: `onMouseDown` on each edge handle attaches document-level `mousemove`/`mouseup` listeners. A `useRef` shadow (`localDatesRef`) avoids stale closures in the event listeners; the ref is cleared and the store is written on `mouseup`, triggering a Firestore save.
- **Fallback dates**: if a wave has no stored `waveDates` entry, the view auto-computes a range from the earliest/latest `closed_at` of its issues (or `milestone.due_on`, or ±30 days from today) so bars always render without requiring explicit setup.
- **Today line**: a red vertical line marks the current date across both the header axis and every row.
- **Tick labels**: Day → "Jan 5", Week → "Jan 5", Quarter → "Q1 '24", Year → "2024". Ticks are generated by walking from a floor-rounded start date in equal increments per granularity.

## Test plan

- [ ] "Timeline" tab appears in the toolbar between "Roadmap" and "Waves".
- [ ] Selecting Timeline shows a granularity dropdown (Day / Week / Quarter / Year) in the toolbar.
- [ ] Switching granularity changes the X-axis tick density and labels.
- [ ] Each wave (milestone) renders as a labeled purple bar spanning its date range.
- [ ] Dragging the left edge of a wave bar adjusts its start date; dragging the right edge adjusts its end date.
- [ ] After releasing a drag, refreshing the page shows the updated dates (Firestore persisted).
- [ ] Closed issues appear as purple dots on the row for their wave, positioned at their `closed_at` date.
- [ ] Issues with no milestone appear in a "No Wave" row at the bottom.
- [ ] A red vertical line marks today across all rows and the header.
- [ ] No regressions in Grid, Kanban, Roadmap, Waves, or User Activities views.

Closes #68