### PR TITLE
Attach images to issues via file picker, drag-drop, URL, and paste

### DIFF
--- a/src/components/CreateIssueModal.tsx
+++ b/src/components/CreateIssueModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import { generateDescription, loadGeminiSettings } from '../lib/gemini';
 import type { IssueContext } from '../lib/gemini';
+import ImageAttacher, { type AttachedImage } from './ImageAttacher';
 
 interface Props {
   defaultProjectId?: string;
@@ -15,6 +16,7 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
 
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
   const [projectId, setProjectId] = useState(defaultProjectId ?? '');
   const [milestoneNumber, setMilestoneNumber] = useState<string>(defaultMilestoneNumber?.toString() ?? '');
   const [statusLabel, setStatusLabel] = useState(defaultStatusLabel ?? '');
@@ -53,9 +55,12 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
     setSubmitting(true);
     setError('');
     try {
+      const imageMarkdown = attachedImages.length > 0
+        ? '\n\n' + attachedImages.map(img => `![${img.name}](${img.url})`).join('\n')
+        : '';
       await createIssue(
         title.trim(),
-        body.trim(),
+        body.trim() + imageMarkdown,
         projectId || undefined,
         milestoneNumber ? Number(milestoneNumber) : undefined,
         statusLabel || undefined,
@@ -127,8 +132,16 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
               value={body}
               onChange={(e) => setBody(e.target.value)}
               placeholder="Add details…"
-              rows={6}
+              rows={5}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+            <ImageAttacher
+              token={token}
+              owner={owner}
+              repo={repo}
+              images={attachedImages}
+              onAdd={(img) => setAttachedImages(prev => [...prev, img])}
+              onRemove={(idx) => setAttachedImages(prev => prev.filter((_, i) => i !== idx))}
             />
           </div>
 

--- a/src/components/EditIssueModal.tsx
+++ b/src/components/EditIssueModal.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useEffect, type RefObject } from 'react';
+import { useState, useRef, useEffect, useMemo, type RefObject } from 'react';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue } from '../types';
 import { generateDescription, loadGeminiSettings } from '../lib/gemini';
 import type { IssueContext } from '../lib/gemini';
-import { fetchIssueImplementation } from '../lib/github';
+import { fetchIssueImplementation, parseImagesFromBody } from '../lib/github';
 import ImageAttacher, { type AttachedImage } from './ImageAttacher';
 import {
   loadAnthropicSettings,
@@ -198,7 +198,9 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
     issue.milestone?.number.toString() ?? ''
   );
 
-  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+  const initialImages = useMemo(() => parseImagesFromBody(body), []); // eslint-disable-line react-hooks/exhaustive-deps
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>(initialImages);
+  const lockedCount = initialImages.length;
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [generating, setGenerating] = useState(false);
@@ -411,8 +413,9 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
       }
       const newMilestone = milestoneNumber ? Number(milestoneNumber) : null;
       const milestoneChanged = newMilestone !== (issue.milestone?.number ?? null);
-      const imageMarkdown = attachedImages.length > 0
-        ? '\n\n' + attachedImages.map(img => `![${img.name}](${img.url})`).join('\n')
+      const newImages = attachedImages.slice(lockedCount);
+      const imageMarkdown = newImages.length > 0
+        ? '\n\n' + newImages.map(img => `![${img.name}](${img.url})`).join('\n')
         : '';
       const savedBody = encodeAiLinks(body.trim() + imageMarkdown, aiLinks);
       await updateIssue(
@@ -531,6 +534,7 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
                     owner={owner}
                     repo={repo}
                     images={attachedImages}
+                    lockedCount={lockedCount}
                     onAdd={(img) => setAttachedImages(prev => [...prev, img])}
                     onRemove={(idx) => setAttachedImages(prev => prev.filter((_, i) => i !== idx))}
                   />

--- a/src/components/EditIssueModal.tsx
+++ b/src/components/EditIssueModal.tsx
@@ -4,6 +4,7 @@ import type { GitHubIssue } from '../types';
 import { generateDescription, loadGeminiSettings } from '../lib/gemini';
 import type { IssueContext } from '../lib/gemini';
 import { fetchIssueImplementation } from '../lib/github';
+import ImageAttacher, { type AttachedImage } from './ImageAttacher';
 import {
   loadAnthropicSettings,
   createSession,
@@ -197,6 +198,7 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
     issue.milestone?.number.toString() ?? ''
   );
 
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [generating, setGenerating] = useState(false);
@@ -409,8 +411,10 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
       }
       const newMilestone = milestoneNumber ? Number(milestoneNumber) : null;
       const milestoneChanged = newMilestone !== (issue.milestone?.number ?? null);
-      // Preserve AI links when saving
-      const savedBody = encodeAiLinks(body.trim(), aiLinks);
+      const imageMarkdown = attachedImages.length > 0
+        ? '\n\n' + attachedImages.map(img => `![${img.name}](${img.url})`).join('\n')
+        : '';
+      const savedBody = encodeAiLinks(body.trim() + imageMarkdown, aiLinks);
       await updateIssue(
         issue.number,
         title.trim(),
@@ -519,8 +523,18 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
                 <textarea
                   value={body}
                   onChange={(e) => setBody(e.target.value)}
-                  className="w-full flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                  className="w-full flex-1 min-h-[6rem] border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                 />
+                <div className="shrink-0 mt-2">
+                  <ImageAttacher
+                    token={token}
+                    owner={owner}
+                    repo={repo}
+                    images={attachedImages}
+                    onAdd={(img) => setAttachedImages(prev => [...prev, img])}
+                    onRemove={(idx) => setAttachedImages(prev => prev.filter((_, i) => i !== idx))}
+                  />
+                </div>
                 <div className="grid grid-cols-2 gap-3 shrink-0">
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">User Activity</label>

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { uploadImageToRepo } from '../lib/github';
+
+export interface AttachedImage {
+  url: string;
+  name: string;
+}
+
+interface Props {
+  token: string;
+  owner: string;
+  repo: string;
+  images: AttachedImage[];
+  onAdd: (img: AttachedImage) => void;
+  onRemove: (idx: number) => void;
+}
+
+function Spinner() {
+  return (
+    <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+    </svg>
+  );
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve((reader.result as string).split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function ImageAttacher({ token, owner, repo, images, onAdd, onRemove }: Props) {
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+  const [dragOver, setDragOver] = useState(false);
+  const [showUrlInput, setShowUrlInput] = useState(false);
+  const [urlInput, setUrlInput] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const onAddRef = useRef(onAdd);
+  useEffect(() => { onAddRef.current = onAdd; }, [onAdd]);
+
+  const handleFiles = useCallback(async (files: File[]) => {
+    const imageFiles = files.filter(f => f.type.startsWith('image/'));
+    if (imageFiles.length === 0) return;
+    setUploading(true);
+    setUploadError('');
+    try {
+      for (const file of imageFiles) {
+        const base64 = await fileToBase64(file);
+        const url = await uploadImageToRepo(token, owner, repo, file.name, base64);
+        onAddRef.current({ url, name: file.name });
+      }
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }, [token, owner, repo]);
+
+  const handleFilesRef = useRef(handleFiles);
+  useEffect(() => { handleFilesRef.current = handleFiles; }, [handleFiles]);
+
+  useEffect(() => {
+    function onPaste(e: ClipboardEvent) {
+      const items = Array.from(e.clipboardData?.items ?? []);
+      const imageItem = items.find(item => item.kind === 'file' && item.type.startsWith('image/'));
+      if (!imageItem) return;
+      e.preventDefault();
+      const file = imageItem.getAsFile();
+      if (file) handleFilesRef.current([file]);
+    }
+    document.addEventListener('paste', onPaste);
+    return () => document.removeEventListener('paste', onPaste);
+  }, []);
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+    handleFiles(Array.from(e.dataTransfer.files));
+  }
+
+  function handleUrlAdd() {
+    const trimmed = urlInput.trim();
+    if (!trimmed) return;
+    const name = trimmed.split('/').pop()?.split('?')[0] ?? 'image';
+    onAdd({ url: trimmed, name });
+    setUrlInput('');
+    setShowUrlInput(false);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div
+        className={`border-2 border-dashed rounded-lg px-3 py-2 transition-colors ${
+          dragOver ? 'border-blue-400 bg-blue-50' : 'border-gray-200 hover:border-gray-300'
+        }`}
+        onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+      >
+        <div className="flex items-center justify-center gap-2 text-xs text-gray-400">
+          {uploading ? (
+            <span className="flex items-center gap-1.5"><Spinner />Uploading…</span>
+          ) : (
+            <>
+              <span>Drop images here or</span>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="text-blue-500 hover:text-blue-700 underline"
+              >
+                pick file
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={() => setShowUrlInput(v => !v)}
+                className="text-blue-500 hover:text-blue-700 underline"
+              >
+                URL
+              </button>
+              <span>· or paste</span>
+            </>
+          )}
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={(e) => { handleFiles(Array.from(e.target.files ?? [])); e.target.value = ''; }}
+        />
+      </div>
+
+      {showUrlInput && (
+        <div className="flex gap-2">
+          <input
+            autoFocus
+            type="url"
+            value={urlInput}
+            onChange={(e) => setUrlInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { e.preventDefault(); handleUrlAdd(); }
+              if (e.key === 'Escape') setShowUrlInput(false);
+            }}
+            placeholder="https://example.com/image.png"
+            className="flex-1 border border-gray-300 rounded-lg px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={handleUrlAdd}
+            disabled={!urlInput.trim()}
+            className="px-3 py-1.5 text-xs bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+          >
+            Add
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowUrlInput(false)}
+            className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {uploadError && <p className="text-red-500 text-xs">{uploadError}</p>}
+
+      {images.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {images.map((img, idx) => (
+            <div key={idx} className="relative group">
+              <a href={img.url} target="_blank" rel="noreferrer">
+                <img
+                  src={img.url}
+                  alt={img.name}
+                  className="w-16 h-16 object-cover rounded-lg border border-gray-200 bg-gray-50"
+                  onError={(e) => {
+                    (e.currentTarget as HTMLImageElement).style.display = 'none';
+                    (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'flex');
+                  }}
+                />
+                <div
+                  style={{ display: 'none' }}
+                  className="w-16 h-16 rounded-lg border border-gray-200 bg-gray-50 flex-col items-center justify-center text-center px-1"
+                >
+                  <svg className="w-5 h-5 text-gray-400 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                  <span className="text-gray-400 text-[9px] leading-tight break-all line-clamp-2">{img.name}</span>
+                </div>
+              </a>
+              <button
+                type="button"
+                onClick={() => onRemove(idx)}
+                className="absolute -top-1 -right-1 w-4 h-4 bg-gray-700 text-white rounded-full text-[10px] items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity leading-none hidden group-hover:flex"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -190,7 +190,7 @@ export default function ImageAttacher({
 
       {/* Gallery */}
       {images.length > 0 && (
-        <div className="space-y-2">
+        <div className="space-y-2" onMouseLeave={() => setHoveredIdx(null)}>
           {/* Magnified preview — expands in the space above the thumbnail row */}
           <div
             className={`overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition-all duration-200 ${
@@ -217,7 +217,6 @@ export default function ImageAttacher({
                   key={idx}
                   className="relative group"
                   onMouseEnter={() => setHoveredIdx(idx)}
-                  onMouseLeave={() => setHoveredIdx(null)}
                 >
                   <a href={img.url} target="_blank" rel="noreferrer">
                     <img

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -39,6 +39,7 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
   const [dragOver, setDragOver] = useState(false);
   const [showUrlInput, setShowUrlInput] = useState(false);
   const [urlInput, setUrlInput] = useState('');
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const onAddRef = useRef(onAdd);
   useEffect(() => { onAddRef.current = onAdd; }, [onAdd]);
@@ -91,6 +92,8 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
     setUrlInput('');
     setShowUrlInput(false);
   }
+
+  const hoveredImage = hoveredIdx !== null ? images[hoveredIdx] : null;
 
   return (
     <div className="space-y-2">
@@ -172,38 +175,65 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
       {uploadError && <p className="text-red-500 text-xs">{uploadError}</p>}
 
       {images.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {images.map((img, idx) => (
-            <div key={idx} className="relative group">
-              <a href={img.url} target="_blank" rel="noreferrer">
+        <div className="space-y-2">
+          {/* Magnified preview — occupies space above the gallery row */}
+          <div
+            className={`overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition-all duration-200 ${
+              hoveredImage ? 'max-h-48 opacity-100' : 'max-h-0 opacity-0 border-transparent'
+            }`}
+          >
+            {hoveredImage && (
+              <a href={hoveredImage.url} target="_blank" rel="noreferrer" className="block">
                 <img
-                  src={img.url}
-                  alt={img.name}
-                  className="w-16 h-16 object-cover rounded-lg border border-gray-200 bg-gray-50"
-                  onError={(e) => {
-                    (e.currentTarget as HTMLImageElement).style.display = 'none';
-                    (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'flex');
-                  }}
+                  src={hoveredImage.url}
+                  alt={hoveredImage.name}
+                  className="w-full max-h-48 object-contain"
                 />
-                <div
-                  style={{ display: 'none' }}
-                  className="w-16 h-16 rounded-lg border border-gray-200 bg-gray-50 flex-col items-center justify-center text-center px-1"
-                >
-                  <svg className="w-5 h-5 text-gray-400 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                  <span className="text-gray-400 text-[9px] leading-tight break-all line-clamp-2">{img.name}</span>
-                </div>
               </a>
-              <button
-                type="button"
-                onClick={() => onRemove(idx)}
-                className="absolute -top-1 -right-1 w-4 h-4 bg-gray-700 text-white rounded-full text-[10px] items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity leading-none hidden group-hover:flex"
+            )}
+          </div>
+
+          {/* Thumbnail row */}
+          <div className="flex flex-wrap gap-2">
+            {images.map((img, idx) => (
+              <div
+                key={idx}
+                className="relative group"
+                onMouseEnter={() => setHoveredIdx(idx)}
+                onMouseLeave={() => setHoveredIdx(null)}
               >
-                ×
-              </button>
-            </div>
-          ))}
+                <a href={img.url} target="_blank" rel="noreferrer">
+                  <img
+                    src={img.url}
+                    alt={img.name}
+                    className={`w-16 h-16 object-cover rounded-lg border bg-gray-50 transition-all duration-150 ${
+                      hoveredIdx === idx ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'
+                    }`}
+                    onError={(e) => {
+                      (e.currentTarget as HTMLImageElement).style.display = 'none';
+                      (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'flex');
+                    }}
+                  />
+                  <div
+                    style={{ display: 'none' }}
+                    className="w-16 h-16 rounded-lg border border-gray-200 bg-gray-50 flex-col items-center justify-center text-center px-1"
+                  >
+                    <svg className="w-5 h-5 text-gray-400 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    <span className="text-gray-400 text-[9px] leading-tight break-all line-clamp-2">{img.name}</span>
+                  </div>
+                </a>
+                <button
+                  type="button"
+                  onClick={() => onRemove(idx)}
+                  className="absolute -top-1 -right-1 w-4 h-4 bg-gray-700 text-white rounded-full text-[10px] items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity leading-none hidden group-hover:flex"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -47,6 +47,7 @@ export default function ImageAttacher({
   const [showUrlInput, setShowUrlInput] = useState(false);
   const [urlInput, setUrlInput] = useState('');
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [hoverPos, setHoverPos] = useState({ x: 0.5, y: 0.5 });
   const fileInputRef = useRef<HTMLInputElement>(null);
   const onAddRef = useRef(onAdd);
   useEffect(() => { onAddRef.current = onAdd; }, [onAdd]);
@@ -91,6 +92,14 @@ export default function ImageAttacher({
     e.preventDefault();
     setDragOver(false);
     handleFiles(Array.from(e.dataTransfer.files));
+  }
+
+  function handleThumbMove(e: React.MouseEvent<HTMLDivElement>) {
+    const r = e.currentTarget.getBoundingClientRect();
+    setHoverPos({
+      x: (e.clientX - r.left) / r.width,
+      y: (e.clientY - r.top) / r.height,
+    });
   }
 
   function handleUrlAdd() {
@@ -194,33 +203,35 @@ export default function ImageAttacher({
           {readOnly ? (
             /* Overlay mode: preview floats absolutely above the thumbnail strip */
             hoveredImage && (
-              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-gray-200 bg-white shadow-xl overflow-hidden flex items-center justify-center">
-                <a href={hoveredImage.url} target="_blank" rel="noreferrer" className="block">
-                  <img
-                    src={hoveredImage.url}
-                    alt={hoveredImage.name}
-                    className="max-h-56 max-w-full object-contain"
-                  />
-                </a>
-              </div>
+              <a
+                href={hoveredImage.url}
+                target="_blank"
+                rel="noreferrer"
+                className="absolute bottom-full left-0 right-0 z-20 mb-2 block h-36 rounded-lg border border-gray-200 shadow-xl overflow-hidden"
+                style={{
+                  backgroundImage: `url(${hoveredImage.url})`,
+                  backgroundSize: '300%',
+                  backgroundPosition: `${hoverPos.x * 100}% ${hoverPos.y * 100}%`,
+                  backgroundRepeat: 'no-repeat',
+                }}
+              />
             )
           ) : (
             /* Inline mode (edit / create): preview expands in flow above thumbnails */
-            <div
-              className={`overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition-all duration-200 ${
-                hoveredImage ? 'max-h-48 opacity-100' : 'max-h-0 opacity-0 border-transparent'
+            <a
+              href={hoveredImage?.url}
+              target="_blank"
+              rel="noreferrer"
+              className={`block rounded-lg border border-gray-200 overflow-hidden transition-all duration-200 ${
+                hoveredImage ? 'h-36 opacity-100' : 'h-0 opacity-0 border-transparent pointer-events-none'
               }`}
-            >
-              {hoveredImage && (
-                <a href={hoveredImage.url} target="_blank" rel="noreferrer" className="flex items-center justify-center">
-                  <img
-                    src={hoveredImage.url}
-                    alt={hoveredImage.name}
-                    className="max-h-48 max-w-full object-contain"
-                  />
-                </a>
-              )}
-            </div>
+              style={hoveredImage ? {
+                backgroundImage: `url(${hoveredImage.url})`,
+                backgroundSize: '300%',
+                backgroundPosition: `${hoverPos.x * 100}% ${hoverPos.y * 100}%`,
+                backgroundRepeat: 'no-repeat',
+              } : undefined}
+            />
           )}
 
           {/* Thumbnail row */}
@@ -231,7 +242,8 @@ export default function ImageAttacher({
                 <div
                   key={idx}
                   className="relative group"
-                  onMouseEnter={() => setHoveredIdx(idx)}
+                  onMouseEnter={(e) => { setHoveredIdx(idx); handleThumbMove(e); }}
+                  onMouseMove={handleThumbMove}
                 >
                   <a href={img.url} target="_blank" rel="noreferrer">
                     <img

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -190,23 +190,38 @@ export default function ImageAttacher({
 
       {/* Gallery */}
       {images.length > 0 && (
-        <div className="space-y-2" onMouseLeave={() => setHoveredIdx(null)}>
-          {/* Magnified preview — expands in the space above the thumbnail row */}
-          <div
-            className={`overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition-all duration-200 ${
-              hoveredImage ? 'max-h-48 opacity-100' : 'max-h-0 opacity-0 border-transparent'
-            }`}
-          >
-            {hoveredImage && (
-              <a href={hoveredImage.url} target="_blank" rel="noreferrer" className="block">
-                <img
-                  src={hoveredImage.url}
-                  alt={hoveredImage.name}
-                  className="w-full max-h-48 object-contain"
-                />
-              </a>
-            )}
-          </div>
+        <div className={readOnly ? 'relative' : 'space-y-2'} onMouseLeave={() => setHoveredIdx(null)}>
+          {readOnly ? (
+            /* Overlay mode: preview floats absolutely above the thumbnail strip */
+            hoveredImage && (
+              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-gray-200 bg-white shadow-xl overflow-hidden flex items-center justify-center">
+                <a href={hoveredImage.url} target="_blank" rel="noreferrer" className="block">
+                  <img
+                    src={hoveredImage.url}
+                    alt={hoveredImage.name}
+                    className="max-h-56 max-w-full object-contain"
+                  />
+                </a>
+              </div>
+            )
+          ) : (
+            /* Inline mode (edit / create): preview expands in flow above thumbnails */
+            <div
+              className={`overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition-all duration-200 ${
+                hoveredImage ? 'max-h-48 opacity-100' : 'max-h-0 opacity-0 border-transparent'
+              }`}
+            >
+              {hoveredImage && (
+                <a href={hoveredImage.url} target="_blank" rel="noreferrer" className="flex items-center justify-center">
+                  <img
+                    src={hoveredImage.url}
+                    alt={hoveredImage.name}
+                    className="max-h-48 max-w-full object-contain"
+                  />
+                </a>
+              )}
+            </div>
+          )}
 
           {/* Thumbnail row */}
           <div className="flex flex-wrap gap-2">

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -199,38 +199,20 @@ export default function ImageAttacher({
 
       {/* Gallery */}
       {images.length > 0 && (
-        <div className={readOnly ? 'relative' : 'space-y-2'} onMouseLeave={() => setHoveredIdx(null)}>
-          {readOnly ? (
-            /* Overlay mode: preview floats absolutely above the thumbnail strip */
-            hoveredImage && (
-              <a
-                href={hoveredImage.url}
-                target="_blank"
-                rel="noreferrer"
-                className="absolute bottom-full left-0 right-0 z-20 mb-2 block h-36 rounded-lg border border-gray-200 shadow-xl overflow-hidden"
-                style={{
-                  backgroundImage: `url(${hoveredImage.url})`,
-                  backgroundSize: '300%',
-                  backgroundPosition: `${hoverPos.x * 100}% ${hoverPos.y * 100}%`,
-                  backgroundRepeat: 'no-repeat',
-                }}
-              />
-            )
-          ) : (
-            /* Inline mode (edit / create): preview expands in flow above thumbnails */
+        <div className="relative" onMouseLeave={() => setHoveredIdx(null)}>
+          {/* Preview — absolute overlay, square, full width of the content area */}
+          {hoveredImage && (
             <a
-              href={hoveredImage?.url}
+              href={hoveredImage.url}
               target="_blank"
               rel="noreferrer"
-              className={`block rounded-lg border border-gray-200 overflow-hidden transition-all duration-200 ${
-                hoveredImage ? 'h-36 opacity-100' : 'h-0 opacity-0 border-transparent pointer-events-none'
-              }`}
-              style={hoveredImage ? {
+              className="absolute bottom-full left-0 right-0 z-30 mb-1 block aspect-square rounded-lg border border-gray-200 shadow-2xl overflow-hidden"
+              style={{
                 backgroundImage: `url(${hoveredImage.url})`,
                 backgroundSize: '300%',
                 backgroundPosition: `${hoverPos.x * 100}% ${hoverPos.y * 100}%`,
                 backgroundRepeat: 'no-repeat',
-              } : undefined}
+              }}
             />
           )}
 

--- a/src/components/ImageAttacher.tsx
+++ b/src/components/ImageAttacher.tsx
@@ -7,12 +7,16 @@ export interface AttachedImage {
 }
 
 interface Props {
-  token: string;
-  owner: string;
-  repo: string;
   images: AttachedImage[];
-  onAdd: (img: AttachedImage) => void;
-  onRemove: (idx: number) => void;
+  onAdd?: (img: AttachedImage) => void;
+  onRemove?: (idx: number) => void;
+  /** When true, hide all upload controls — gallery only. */
+  readOnly?: boolean;
+  /** Images at indices 0..lockedCount-1 have no remove button (they're from the saved body). */
+  lockedCount?: number;
+  token?: string;
+  owner?: string;
+  repo?: string;
 }
 
 function Spinner() {
@@ -33,7 +37,10 @@ async function fileToBase64(file: File): Promise<string> {
   });
 }
 
-export default function ImageAttacher({ token, owner, repo, images, onAdd, onRemove }: Props) {
+export default function ImageAttacher({
+  images, onAdd, onRemove, readOnly = false, lockedCount = 0,
+  token = '', owner = '', repo = '',
+}: Props) {
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState('');
   const [dragOver, setDragOver] = useState(false);
@@ -45,6 +52,7 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
   useEffect(() => { onAddRef.current = onAdd; }, [onAdd]);
 
   const handleFiles = useCallback(async (files: File[]) => {
+    if (readOnly || !onAddRef.current) return;
     const imageFiles = files.filter(f => f.type.startsWith('image/'));
     if (imageFiles.length === 0) return;
     setUploading(true);
@@ -60,12 +68,13 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
     } finally {
       setUploading(false);
     }
-  }, [token, owner, repo]);
+  }, [token, owner, repo, readOnly]);
 
   const handleFilesRef = useRef(handleFiles);
   useEffect(() => { handleFilesRef.current = handleFiles; }, [handleFiles]);
 
   useEffect(() => {
+    if (readOnly) return;
     function onPaste(e: ClipboardEvent) {
       const items = Array.from(e.clipboardData?.items ?? []);
       const imageItem = items.find(item => item.kind === 'file' && item.type.startsWith('image/'));
@@ -76,7 +85,7 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
     }
     document.addEventListener('paste', onPaste);
     return () => document.removeEventListener('paste', onPaste);
-  }, []);
+  }, [readOnly]);
 
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
@@ -86,7 +95,7 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
 
   function handleUrlAdd() {
     const trimmed = urlInput.trim();
-    if (!trimmed) return;
+    if (!trimmed || !onAdd) return;
     const name = trimmed.split('/').pop()?.split('?')[0] ?? 'image';
     onAdd({ url: trimmed, name });
     setUrlInput('');
@@ -97,86 +106,92 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
 
   return (
     <div className="space-y-2">
-      <div
-        className={`border-2 border-dashed rounded-lg px-3 py-2 transition-colors ${
-          dragOver ? 'border-blue-400 bg-blue-50' : 'border-gray-200 hover:border-gray-300'
-        }`}
-        onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={handleDrop}
-      >
-        <div className="flex items-center justify-center gap-2 text-xs text-gray-400">
-          {uploading ? (
-            <span className="flex items-center gap-1.5"><Spinner />Uploading…</span>
-          ) : (
-            <>
-              <span>Drop images here or</span>
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="text-blue-500 hover:text-blue-700 underline"
-              >
-                pick file
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={() => setShowUrlInput(v => !v)}
-                className="text-blue-500 hover:text-blue-700 underline"
-              >
-                URL
-              </button>
-              <span>· or paste</span>
-            </>
-          )}
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          className="hidden"
-          onChange={(e) => { handleFiles(Array.from(e.target.files ?? [])); e.target.value = ''; }}
-        />
-      </div>
+      {/* Upload controls — hidden in readOnly mode */}
+      {!readOnly && (
+        <>
+          <div
+            className={`border-2 border-dashed rounded-lg px-3 py-2 transition-colors ${
+              dragOver ? 'border-blue-400 bg-blue-50' : 'border-gray-200 hover:border-gray-300'
+            }`}
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={handleDrop}
+          >
+            <div className="flex items-center justify-center gap-2 text-xs text-gray-400">
+              {uploading ? (
+                <span className="flex items-center gap-1.5"><Spinner />Uploading…</span>
+              ) : (
+                <>
+                  <span>Drop images here or</span>
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="text-blue-500 hover:text-blue-700 underline"
+                  >
+                    pick file
+                  </button>
+                  <span>·</span>
+                  <button
+                    type="button"
+                    onClick={() => setShowUrlInput(v => !v)}
+                    className="text-blue-500 hover:text-blue-700 underline"
+                  >
+                    URL
+                  </button>
+                  <span>· or paste</span>
+                </>
+              )}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={(e) => { handleFiles(Array.from(e.target.files ?? [])); e.target.value = ''; }}
+            />
+          </div>
 
-      {showUrlInput && (
-        <div className="flex gap-2">
-          <input
-            autoFocus
-            type="url"
-            value={urlInput}
-            onChange={(e) => setUrlInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); handleUrlAdd(); }
-              if (e.key === 'Escape') setShowUrlInput(false);
-            }}
-            placeholder="https://example.com/image.png"
-            className="flex-1 border border-gray-300 rounded-lg px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          <button
-            type="button"
-            onClick={handleUrlAdd}
-            disabled={!urlInput.trim()}
-            className="px-3 py-1.5 text-xs bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
-          >
-            Add
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowUrlInput(false)}
-            className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
-          >
-            Cancel
-          </button>
-        </div>
+          {showUrlInput && (
+            <div className="flex gap-2">
+              <input
+                autoFocus
+                type="url"
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.preventDefault(); handleUrlAdd(); }
+                  if (e.key === 'Escape') setShowUrlInput(false);
+                }}
+                placeholder="https://example.com/image.png"
+                className="flex-1 border border-gray-300 rounded-lg px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <button
+                type="button"
+                onClick={handleUrlAdd}
+                disabled={!urlInput.trim()}
+                className="px-3 py-1.5 text-xs bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowUrlInput(false)}
+                className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {uploadError && <p className="text-red-500 text-xs">{uploadError}</p>}
+        </>
       )}
 
-      {uploadError && <p className="text-red-500 text-xs">{uploadError}</p>}
-
+      {/* Gallery */}
       {images.length > 0 && (
         <div className="space-y-2">
-          {/* Magnified preview — occupies space above the gallery row */}
+          {/* Magnified preview — expands in the space above the thumbnail row */}
           <div
             className={`overflow-hidden rounded-lg border border-gray-200 bg-gray-50 transition-all duration-200 ${
               hoveredImage ? 'max-h-48 opacity-100' : 'max-h-0 opacity-0 border-transparent'
@@ -195,44 +210,49 @@ export default function ImageAttacher({ token, owner, repo, images, onAdd, onRem
 
           {/* Thumbnail row */}
           <div className="flex flex-wrap gap-2">
-            {images.map((img, idx) => (
-              <div
-                key={idx}
-                className="relative group"
-                onMouseEnter={() => setHoveredIdx(idx)}
-                onMouseLeave={() => setHoveredIdx(null)}
-              >
-                <a href={img.url} target="_blank" rel="noreferrer">
-                  <img
-                    src={img.url}
-                    alt={img.name}
-                    className={`w-16 h-16 object-cover rounded-lg border bg-gray-50 transition-all duration-150 ${
-                      hoveredIdx === idx ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'
-                    }`}
-                    onError={(e) => {
-                      (e.currentTarget as HTMLImageElement).style.display = 'none';
-                      (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'flex');
-                    }}
-                  />
-                  <div
-                    style={{ display: 'none' }}
-                    className="w-16 h-16 rounded-lg border border-gray-200 bg-gray-50 flex-col items-center justify-center text-center px-1"
-                  >
-                    <svg className="w-5 h-5 text-gray-400 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                    <span className="text-gray-400 text-[9px] leading-tight break-all line-clamp-2">{img.name}</span>
-                  </div>
-                </a>
-                <button
-                  type="button"
-                  onClick={() => onRemove(idx)}
-                  className="absolute -top-1 -right-1 w-4 h-4 bg-gray-700 text-white rounded-full text-[10px] items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity leading-none hidden group-hover:flex"
+            {images.map((img, idx) => {
+              const removable = !readOnly && onRemove != null && idx >= lockedCount;
+              return (
+                <div
+                  key={idx}
+                  className="relative group"
+                  onMouseEnter={() => setHoveredIdx(idx)}
+                  onMouseLeave={() => setHoveredIdx(null)}
                 >
-                  ×
-                </button>
-              </div>
-            ))}
+                  <a href={img.url} target="_blank" rel="noreferrer">
+                    <img
+                      src={img.url}
+                      alt={img.name}
+                      className={`w-16 h-16 object-cover rounded-lg border bg-gray-50 transition-all duration-150 ${
+                        hoveredIdx === idx ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'
+                      }`}
+                      onError={(e) => {
+                        (e.currentTarget as HTMLImageElement).style.display = 'none';
+                        (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'flex');
+                      }}
+                    />
+                    <div
+                      style={{ display: 'none' }}
+                      className="w-16 h-16 rounded-lg border border-gray-200 bg-gray-50 flex-col items-center justify-center text-center px-1"
+                    >
+                      <svg className="w-5 h-5 text-gray-400 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                      </svg>
+                      <span className="text-gray-400 text-[9px] leading-tight break-all line-clamp-2">{img.name}</span>
+                    </div>
+                  </a>
+                  {removable && (
+                    <button
+                      type="button"
+                      onClick={() => onRemove(idx)}
+                      className="absolute -top-1 -right-1 w-4 h-4 bg-gray-700 text-white rounded-full text-[10px] items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity leading-none hidden group-hover:flex"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/components/IssueReadModal.tsx
+++ b/src/components/IssueReadModal.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import type { GitHubIssue } from '../types';
 import { useAppStore } from '../store/appStore';
 import EditIssueModal from './EditIssueModal';
 import { parseMarkdownToHTML } from '../lib/markdown';
+import { parseImagesFromBody } from '../lib/github';
+import ImageAttacher from './ImageAttacher';
 
 interface Props {
   issue: GitHubIssue;
@@ -49,6 +51,7 @@ export default function IssueReadModal({ issue, onClose }: Props) {
   })();
 
   const renderedBody = displayBody.trim() ? parseMarkdownToHTML(displayBody) : null;
+  const galleryImages = useMemo(() => parseImagesFromBody(displayBody), [displayBody]);
 
   const nativeStatus = kanbanIssueStatuses[issue.number] ?? (issue.state === 'open' ? 'Todo' : null);
   const statusDisplayLabel = nativeStatus ?? (issue.state === 'closed' ? 'Closed' : 'Todo');
@@ -235,7 +238,7 @@ export default function IssueReadModal({ issue, onClose }: Props) {
         </div>
 
         {/* ── Body ───────────────────────────────────────────────────── */}
-        <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
           {renderedBody ? (
             <div
               className="issue-body"
@@ -245,6 +248,12 @@ export default function IssueReadModal({ issue, onClose }: Props) {
             />
           ) : (
             <p className="text-sm text-gray-400 italic">No description provided.</p>
+          )}
+          {galleryImages.length > 0 && (
+            <div className="border-t border-gray-100 pt-4">
+              <p className="text-xs font-medium text-gray-400 mb-2">Attachments</p>
+              <ImageAttacher readOnly images={galleryImages} />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/IssueReadModal.tsx
+++ b/src/components/IssueReadModal.tsx
@@ -238,7 +238,7 @@ export default function IssueReadModal({ issue, onClose }: Props) {
         </div>
 
         {/* ── Body ───────────────────────────────────────────────────── */}
-        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+        <div className="flex-1 overflow-y-auto px-6 py-4 relative">
           {renderedBody ? (
             <div
               className="issue-body"
@@ -250,8 +250,7 @@ export default function IssueReadModal({ issue, onClose }: Props) {
             <p className="text-sm text-gray-400 italic">No description provided.</p>
           )}
           {galleryImages.length > 0 && (
-            <div className="border-t border-gray-100 pt-4">
-              <p className="text-xs font-medium text-gray-400 mb-2">Attachments</p>
+            <div className="sticky bottom-0 -mx-6 px-6 py-2 bg-white/85 backdrop-blur-sm">
               <ImageAttacher readOnly images={galleryImages} />
             </div>
           )}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,5 +1,17 @@
 import type { AiLinks } from './anthropic';
 
+export interface ParsedImage { url: string; name: string; }
+
+export function parseImagesFromBody(body: string): ParsedImage[] {
+  const regex = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+  const images: ParsedImage[] = [];
+  let match;
+  while ((match = regex.exec(body)) !== null) {
+    images.push({ name: match[1] || 'image', url: match[2] });
+  }
+  return images;
+}
+
 export async function uploadImageToRepo(
   token: string,
   owner: string,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,5 +1,34 @@
 import type { AiLinks } from './anthropic';
 
+export async function uploadImageToRepo(
+  token: string,
+  owner: string,
+  repo: string,
+  filename: string,
+  base64Content: string,
+): Promise<string> {
+  const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const path = `.github/assets/${Date.now()}-${safeName}`;
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: 'Add image attachment', content: base64Content }),
+    },
+  );
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { message?: string };
+    throw new Error(err.message ?? `Upload failed: ${res.status}`);
+  }
+  const json = await res.json() as { content: { download_url: string } };
+  return json.content.download_url;
+}
+
 /**
  * Fetch implementation links (branch + PR) for an issue directly from GitHub.
  * Strategy:


### PR DESCRIPTION
## Summary

- Adds a new `ImageAttacher` component that renders below the description textarea in both the Create and Edit issue modals, supporting four attachment methods: local file picker, drag-and-drop onto the drop zone, direct image URL, and clipboard paste anywhere in the modal.
- Images are uploaded to the repository at `.github/assets/` via the official GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`), making them natively hosted on GitHub without any third-party storage.
- Attached images are tracked in component state and displayed as a thumbnail gallery; on form submit their markdown (`![name](url)`) is appended to the issue body so they persist in the GitHub issue.

## Implementation notes

- Upload goes to `.github/assets/{timestamp}-{filename}` on the repo's default branch, which means images survive as long as the repo does. For private repos, `raw.githubusercontent.com` thumbnails require auth — GitHub's issue renderer handles this automatically in the GitHub UI.
- The paste listener is registered on `document` via `useEffect` and torn down on unmount, so it captures paste anywhere in the modal without needing to intercept the textarea's native paste event.
- URL-attached images skip the upload step and are added directly to the gallery (they're already externally hosted).

## Test plan

- [ ] Open "New Issue" modal — drag an image file onto the drop zone and verify the thumbnail appears.
- [ ] Click "pick file" and select an image from disk; confirm it uploads and appears in the gallery.
- [ ] Click "URL", enter a public image URL, press Enter — thumbnail renders (or filename fallback for non-CORS sources).
- [ ] Copy an image to clipboard (e.g. screenshot) and paste while the modal is open — upload triggers automatically.
- [ ] Submit the form and verify the issue body on GitHub contains the correct `![...]()` markdown and the image renders inline.
- [ ] Repeat all steps in "Edit Issue" modal.
- [ ] Remove a thumbnail via the × hover button; verify it's excluded from the saved body.

Closes #51