### PR TITLE
GitHub SSO

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "taxfix-hackathon-2025-93c2"
+    "default": "githubstorymap"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .env.local
 *.local
 .firebase
+.DS_Store

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,11 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if true;
+    match /userProfiles/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+    match /storyMaps/{repoKey} {
+      allow read, write: if request.auth != null;
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 import { useAppStore } from './store/appStore';
+import { observeAuth, getCachedGithubToken } from './lib/auth';
+import Login from './components/Login';
 import Setup from './components/Setup';
 import Header from './components/Header';
 import StoryMap from './components/StoryMap';
@@ -12,18 +14,46 @@ import TimelineView from './components/TimelineView';
 import SettingsView from './components/SettingsView';
 
 export default function App() {
-  const { token, owner, repo, issues, loading, error, fetchIssues, fetchLabels, fetchProjects, fetchMilestones, fetchAllProjectStatuses, view } = useAppStore();
+  const {
+    token, owner, repo, issues, loading, error,
+    fetchIssues, fetchLabels, fetchProjects, fetchMilestones, fetchAllProjectStatuses,
+    view, authStatus, setAuthSignedIn, setAuthSignedOut,
+  } = useAppStore();
+
+  useEffect(() => {
+    const unsub = observeAuth((user) => {
+      if (user) {
+        const cachedToken = getCachedGithubToken();
+        const login =
+          user.providerData.find((p) => p.providerId === 'github.com')?.displayName ?? '';
+        setAuthSignedIn(cachedToken, login);
+      } else {
+        setAuthSignedOut();
+      }
+    });
+    return unsub;
+  }, [setAuthSignedIn, setAuthSignedOut]);
 
   const isConfigured = Boolean(token && owner && repo);
 
   useEffect(() => {
-    if (isConfigured && issues.length === 0) {
+    if (authStatus === 'signed-in' && isConfigured && issues.length === 0) {
       fetchIssues();
       fetchLabels();
       fetchProjects().then(() => fetchAllProjectStatuses());
       fetchMilestones();
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [authStatus, isConfigured]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (authStatus === 'loading') {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-400 text-sm">Loading…</div>
+      </div>
+    );
+  }
+
+  if (authStatus === 'signed-out' || !token) return <Login />;
 
   if (!isConfigured) return <Setup />;
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ const VIEW_LABELS: Record<string, string> = {
 };
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, reset, loading, view, setView, showClosedIssues, toggleShowClosedIssues, kanbanShowClosedIssues, toggleKanbanShowClosedIssues } = useAppStore();
+  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, signOut, loading, view, setView, showClosedIssues, toggleShowClosedIssues, kanbanShowClosedIssues, toggleKanbanShowClosedIssues } = useAppStore();
   const activeShowClosed = (view === 'kanban' || view === 'table') ? kanbanShowClosedIssues : showClosedIssues;
   const activeToggleClosed = (view === 'kanban' || view === 'table') ? toggleKanbanShowClosedIssues : toggleShowClosedIssues;
   const [showCreate, setShowCreate] = useState(false);
@@ -104,10 +104,10 @@ export default function Header() {
               </span>
             </div>
 
-            {/* Disconnect */}
+            {/* Sign out */}
             <div className="relative group">
               <button
-                onClick={reset}
+                onClick={() => { void signOut(); }}
                 className="p-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
@@ -115,7 +115,7 @@ export default function Header() {
                 </svg>
               </button>
               <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity">
-                Disconnect
+                Sign out
               </span>
             </div>
           </div>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useAppStore } from '../store/appStore';
+
+export default function Login() {
+  const { signInWithGithub, authError, clearAuthError } = useAppStore();
+  const [busy, setBusy] = useState(false);
+
+  async function handleClick() {
+    setBusy(true);
+    clearAuthError();
+    try {
+      await signInWithGithub();
+    } catch {
+      // store already captured authError
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-200 w-full max-w-md p-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-1">GitHub Story Map</h1>
+        <p className="text-gray-500 text-sm mb-6">
+          Sign in with your GitHub account to manage your story map.
+        </p>
+
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={busy}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38v-1.34c-2.23.49-2.7-1.07-2.7-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82a7.65 7.65 0 014 0c1.54-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.74-3.65 3.94.29.25.54.74.54 1.49v2.21c0 .21.15.46.55.38A8 8 0 0016 8c0-4.42-3.58-8-8-8z" />
+          </svg>
+          {busy ? 'Signing in…' : 'Sign in with GitHub'}
+        </button>
+
+        {authError && (
+          <div className="mt-4 bg-red-50 border border-red-200 rounded-lg px-3 py-2 text-sm text-red-700">
+            {authError}
+          </div>
+        )}
+
+        <p className="text-xs text-gray-400 mt-6">
+          We request the <code>repo</code> and <code>project</code> scopes so the app can read & write
+          issues, milestones, labels, and Projects v2 fields on your behalf.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -78,8 +78,7 @@ export default function SettingsView() {
   const [notes, setNotes] = useState('');
 
   useEffect(() => {
-    if (!owner) return;
-    loadUserProfile(owner).then((profile) => {
+    loadUserProfile().then((profile) => {
       if (!profile) return;
       if (profile.address) setAddress(profile.address);
       if (profile.phone) setPhone(profile.phone);
@@ -87,7 +86,7 @@ export default function SettingsView() {
       if (profile.dateOfBirth) setDateOfBirth(profile.dateOfBirth);
       if (profile.notes) setNotes(profile.notes);
     }).catch(() => {});
-  }, [owner]);
+  }, []);
 
   const calculatedAge = (() => {
     if (!dateOfBirth) return null;
@@ -154,17 +153,14 @@ export default function SettingsView() {
         fetchProjects().then(() => fetchAllProjectStatuses());
         fetchMilestones();
       }
-      const currentOwner = ghOwner.trim() || owner;
-      if (currentOwner) {
-        saveUserProfile(currentOwner, {
-          address: address.trim() || undefined,
-          phone: phone.trim() || undefined,
-          signupDate: signupDate || undefined,
-          dateOfBirth: dateOfBirth || undefined,
-          age: calculatedAge ?? undefined,
-          notes: notes.trim() || undefined,
-        }).catch(() => {});
-      }
+      saveUserProfile({
+        address: address.trim() || undefined,
+        phone: phone.trim() || undefined,
+        signupDate: signupDate || undefined,
+        dateOfBirth: dateOfBirth || undefined,
+        age: calculatedAge ?? undefined,
+        notes: notes.trim() || undefined,
+      }).catch(() => {});
     } else if (activeTab === 'describing') {
       saveGeminiSettings({ apiKey, model, exampleIssueNumbers: exampleNumbers, extraInstructions });
     } else if (activeTab === 'coding') {

--- a/src/components/Setup.tsx
+++ b/src/components/Setup.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAppStore } from '../store/appStore';
 
 interface Repo {
@@ -8,45 +8,44 @@ interface Repo {
 }
 
 export default function Setup() {
-  const { setCredentials, fetchIssues, fetchLabels, fetchProjects, fetchMilestones } = useAppStore();
-  const [token, setToken] = useState('');
+  const { token, setCredentials, signOut, fetchIssues, fetchLabels, fetchProjects, fetchMilestones } = useAppStore();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [fetchingRepos, setFetchingRepos] = useState(false);
   const [repoError, setRepoError] = useState('');
   const [search, setSearch] = useState('');
   const [connecting, setConnecting] = useState(false);
 
-  async function handleTokenBlur(): Promise<void> {
-    const t = token.trim();
-    if (!t) return;
+  useEffect(() => {
+    if (!token) return;
     setFetchingRepos(true);
     setRepoError('');
-    setRepos([]);
-    try {
-      const all: Repo[] = [];
-      let page = 1;
-      while (true) {
-        const res = await fetch(
-          `https://api.github.com/user/repos?per_page=100&page=${page}&sort=updated`,
-          { headers: { Authorization: `token ${t}`, Accept: 'application/vnd.github.v3+json' } },
-        );
-        if (!res.ok) throw new Error('Invalid token or insufficient scopes');
-        const data: Repo[] = await res.json();
-        all.push(...data);
-        if (data.length < 100) break;
-        page++;
+    (async () => {
+      try {
+        const all: Repo[] = [];
+        let page = 1;
+        while (true) {
+          const res = await fetch(
+            `https://api.github.com/user/repos?per_page=100&page=${page}&sort=updated`,
+            { headers: { Authorization: `token ${token}`, Accept: 'application/vnd.github.v3+json' } },
+          );
+          if (!res.ok) throw new Error('GitHub returned ' + res.status + ' — your session may have expired. Sign out and back in.');
+          const data: Repo[] = await res.json();
+          all.push(...data);
+          if (data.length < 100) break;
+          page++;
+        }
+        setRepos(all);
+      } catch (e) {
+        setRepoError(e instanceof Error ? e.message : 'Failed to fetch repositories');
+      } finally {
+        setFetchingRepos(false);
       }
-      setRepos(all);
-    } catch (e) {
-      setRepoError(e instanceof Error ? e.message : 'Failed to fetch repositories');
-    } finally {
-      setFetchingRepos(false);
-    }
-  }
+    })();
+  }, [token]);
 
   async function handleSelectRepo(fullName: string) {
     const [owner, repo] = fullName.split('/');
-    setCredentials(token.trim(), owner, repo);
+    setCredentials(token, owner, repo);
     setConnecting(true);
     await Promise.all([fetchIssues(), fetchLabels(), fetchProjects(), fetchMilestones()]);
     setConnecting(false);
@@ -59,39 +58,21 @@ export default function Setup() {
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-2xl shadow-sm border border-gray-200 w-full max-w-md p-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-1">GitHub Story Map</h1>
+        <div className="flex items-start justify-between mb-1">
+          <h1 className="text-2xl font-bold text-gray-900">GitHub Story Map</h1>
+          <button
+            type="button"
+            onClick={() => { void signOut(); }}
+            className="text-xs text-gray-400 hover:text-gray-600 underline"
+          >
+            Sign out
+          </button>
+        </div>
         <p className="text-gray-500 text-sm mb-6">
-          Visualize your GitHub issues as user activities, stories, and tasks.
+          Pick the repository whose issues you want to visualize.
         </p>
 
         <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              GitHub Personal Access Token
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="password"
-                value={token}
-                onChange={(e) => { setToken(e.target.value); setRepos([]); setRepoError(''); }}
-                onKeyDown={(e) => e.key === 'Enter' && handleTokenBlur()}
-                placeholder="ghp_..."
-                className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-              <button
-                type="button"
-                onClick={handleTokenBlur}
-                disabled={!token.trim() || fetchingRepos}
-                className="px-3 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
-              >
-                {fetchingRepos ? 'Loading…' : 'Connect'}
-              </button>
-            </div>
-            <p className="text-xs text-gray-400 mt-1">
-              Classic PAT with <code>repo</code> and <code>project</code> scopes. Stored in localStorage only.
-            </p>
-          </div>
-
           {fetchingRepos && (
             <p className="text-sm text-gray-400">Fetching repositories…</p>
           )}
@@ -102,9 +83,6 @@ export default function Setup() {
 
           {repos.length > 0 && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Select a repository
-              </label>
               <input
                 type="text"
                 value={search}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,54 @@
+import {
+  GithubAuthProvider,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+  getAdditionalUserInfo,
+  type User,
+} from 'firebase/auth';
+import { auth } from './firebase';
+
+const TOKEN_KEY = 'gh_token';
+
+export function getCachedGithubToken(): string {
+  return localStorage.getItem(TOKEN_KEY) ?? '';
+}
+
+export function setCachedGithubToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearCachedGithubToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export interface SignInResult {
+  user: User;
+  githubToken: string;
+  githubLogin: string;
+}
+
+export async function signInWithGithub(): Promise<SignInResult> {
+  const provider = new GithubAuthProvider();
+  provider.addScope('repo');
+  provider.addScope('project');
+  const result = await signInWithPopup(auth, provider);
+  const credential = GithubAuthProvider.credentialFromResult(result);
+  const githubToken = credential?.accessToken;
+  if (!githubToken) {
+    throw new Error('Sign-in succeeded but no GitHub access token was returned.');
+  }
+  const githubLogin =
+    (getAdditionalUserInfo(result)?.username as string | undefined) ?? '';
+  setCachedGithubToken(githubToken);
+  return { user: result.user, githubToken, githubLogin };
+}
+
+export async function signOutFromFirebase(): Promise<void> {
+  clearCachedGithubToken();
+  await signOut(auth);
+}
+
+export function observeAuth(cb: (user: User | null) => void): () => void {
+  return onAuthStateChanged(auth, cb);
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
 import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
 import type { StoryMapLayout } from '../types';
 
@@ -26,6 +27,7 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);
 
 function repoKey(owner: string, repo: string) {
   return `${owner}__${repo}`;
@@ -49,13 +51,17 @@ export async function saveLayout(
   await setDoc(ref, layout);
 }
 
-export async function loadUserProfile(owner: string): Promise<UserProfile | null> {
-  const ref = doc(db, 'userProfiles', owner);
+export async function loadUserProfile(): Promise<UserProfile | null> {
+  const uid = auth.currentUser?.uid;
+  if (!uid) return null;
+  const ref = doc(db, 'userProfiles', uid);
   const snap = await getDoc(ref);
   return snap.exists() ? (snap.data() as UserProfile) : null;
 }
 
-export async function saveUserProfile(owner: string, profile: UserProfile): Promise<void> {
-  const ref = doc(db, 'userProfiles', owner);
+export async function saveUserProfile(profile: UserProfile): Promise<void> {
+  const uid = auth.currentUser?.uid;
+  if (!uid) return;
+  const ref = doc(db, 'userProfiles', uid);
   await setDoc(ref, profile, { merge: true });
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2,11 +2,19 @@ import { create } from 'zustand';
 import { Octokit } from '@octokit/rest';
 import type { GitHubIssue, GitHubMilestone, GitHubProject, StoryMapLayout } from '../types';
 import { loadLayout, saveLayout, loadUserProfile, saveUserProfile } from '../lib/firebase';
+import {
+  signInWithGithub,
+  signOutFromFirebase,
+  getCachedGithubToken,
+  clearCachedGithubToken,
+} from '../lib/auth';
 
 interface AppState {
   token: string;
   owner: string;
   repo: string;
+  authStatus: 'loading' | 'signed-in' | 'signed-out';
+  authError: string | null;
   issues: GitHubIssue[];
   layout: StoryMapLayout;
   loading: boolean;
@@ -37,6 +45,11 @@ interface AppState {
   kanbanStatusColors: Record<string, string>;
 
   setCredentials: (token: string, owner: string, repo: string) => void;
+  signInWithGithub: () => Promise<void>;
+  signOut: () => Promise<void>;
+  setAuthSignedIn: (token: string, login: string) => void;
+  setAuthSignedOut: () => void;
+  clearAuthError: () => void;
   fetchIssues: () => Promise<void>;
   toggleShowClosedIssues: () => void;
   toggleKanbanShowClosedIssues: () => void;
@@ -144,9 +157,11 @@ async function ensureLabel(
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
-  token: localStorage.getItem('gh_token') ?? import.meta.env.VITE_GITHUB_TOKEN ?? '',
+  token: getCachedGithubToken() || (import.meta.env.VITE_GITHUB_TOKEN ?? ''),
   owner: localStorage.getItem('gh_owner') ?? import.meta.env.VITE_GITHUB_OWNER ?? '',
   repo: localStorage.getItem('gh_repo') ?? import.meta.env.VITE_GITHUB_REPO ?? '',
+  authStatus: 'loading',
+  authError: null,
   issues: [],
   layout: emptyLayout,
   loading: false,
@@ -176,6 +191,50 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ token, owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {} });
   },
 
+  signInWithGithub: async () => {
+    set({ authError: null });
+    try {
+      const { githubToken } = await signInWithGithub();
+      set({ token: githubToken, authStatus: 'signed-in' });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'GitHub sign-in failed.';
+      set({ authError: msg });
+      throw e;
+    }
+  },
+
+  signOut: async () => {
+    try {
+      await signOutFromFirebase();
+    } finally {
+      localStorage.removeItem('gh_owner');
+      localStorage.removeItem('gh_repo');
+      set({
+        token: '', owner: '', repo: '',
+        authStatus: 'signed-out', authError: null,
+        issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [],
+        projects: [], projectIssues: {}, kanbanMilestoneNumber: null,
+        kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {},
+        kanbanItemIds: {}, kanbanStatusColors: {},
+      });
+    }
+  },
+
+  setAuthSignedIn: (token, login) => {
+    set((state) => ({
+      authStatus: 'signed-in',
+      token: token || state.token,
+      owner: state.owner || login,
+    }));
+  },
+
+  setAuthSignedOut: () => {
+    clearCachedGithubToken();
+    set({ authStatus: 'signed-out', token: '', authError: null });
+  },
+
+  clearAuthError: () => set({ authError: null }),
+
   reset: () => {
     localStorage.removeItem('gh_token');
     localStorage.removeItem('gh_owner');
@@ -187,19 +246,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setTimelineGranularity: (g) => {
     set({ timelineGranularity: g });
-    const { owner } = get();
-    if (owner) saveUserProfile(owner, { timelineGranularity: g }).catch(() => {});
+    saveUserProfile({ timelineGranularity: g }).catch(() => {});
   },
 
   toggleTimelineShowIssues: () => {
     const next = !get().timelineShowIssues;
     set({ timelineShowIssues: next });
-    const { owner } = get();
-    if (owner) saveUserProfile(owner, { timelineShowIssues: next }).catch(() => {});
+    saveUserProfile({ timelineShowIssues: next }).catch(() => {});
   },
 
   reorderTimelineMilestones: (fromIndex, toIndex) => {
-    const { timelineMilestoneOrder, milestones, layout, owner } = get();
+    const { timelineMilestoneOrder, milestones, layout } = get();
     const base = timelineMilestoneOrder.length
       ? timelineMilestoneOrder
       : [...milestones].sort((a, b) => {
@@ -214,7 +271,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const [moved] = newOrder.splice(fromIndex, 1);
     newOrder.splice(toIndex, 0, moved);
     set({ timelineMilestoneOrder: newOrder });
-    if (owner) saveUserProfile(owner, { timelineMilestoneOrder: newOrder }).catch(() => {});
+    saveUserProfile({ timelineMilestoneOrder: newOrder }).catch(() => {});
   },
 
   setWaveDate: async (milestoneNumber, start, end) => {
@@ -379,7 +436,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       try {
         [savedLayout, userProfile] = await Promise.all([
           loadLayout(owner, repo),
-          loadUserProfile(owner),
+          loadUserProfile(),
         ]);
       } catch (firestoreErr) {
         console.warn('Firestore unavailable, building layout from issues', firestoreErr);
@@ -931,8 +988,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setKanbanMilestone: (milestoneNumber) => {
     set({ kanbanMilestoneNumber: milestoneNumber });
-    const { owner } = get();
-    if (owner) saveUserProfile(owner, { kanbanMilestoneNumber: milestoneNumber ?? null }).catch(() => {});
+    saveUserProfile({ kanbanMilestoneNumber: milestoneNumber ?? null }).catch(() => {});
   },
 
   fetchAllProjectStatuses: async () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -639,8 +639,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { token, owner, repo, layout } = get();
     if (!token || !owner) return;
 
+    type IssueContent = { number: number; repository: { nameWithOwner: string } };
     type ProjectNode = GitHubProject & {
-      items: { nodes: Array<{ content: { number: number } | null }> };
+      items: { nodes: Array<{ content: IssueContent | null }> };
     };
 
     const data = await gql<{
@@ -652,7 +653,7 @@ export const useAppStore = create<AppState>((set, get) => ({
             projectsV2(first: 50) {
               nodes {
                 id number title shortDescription url closed
-                items(first: 100) { nodes { content { ... on Issue { number } } } }
+                items(first: 100) { nodes { content { ... on Issue { number repository { nameWithOwner } } } } }
               }
             }
           }
@@ -660,7 +661,7 @@ export const useAppStore = create<AppState>((set, get) => ({
             projectsV2(first: 50) {
               nodes {
                 id number title shortDescription url closed
-                items(first: 100) { nodes { content { ... on Issue { number } } } }
+                items(first: 100) { nodes { content { ... on Issue { number repository { nameWithOwner } } } } }
               }
             }
           }
@@ -668,13 +669,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     `, { login: owner });
 
+    const repoFullName = `${owner}/${repo}`;
     const nodes = data.repositoryOwner?.projectsV2?.nodes ?? [];
     const projects: GitHubProject[] = nodes.map(({ items: _items, ...p }) => p);
     const projectIssues: Record<string, number[]> = {};
     for (const node of nodes) {
       projectIssues[node.id] = node.items.nodes
-        .map((item) => item.content?.number)
-        .filter((n): n is number => n !== undefined);
+        .map((item) => item.content)
+        .filter((c): c is IssueContent =>
+          !!c && c.repository?.nameWithOwner === repoFullName,
+        )
+        .map((c) => c.number);
     }
 
     // Sync userActivityOrder with current project numbers (preserving saved order, appending new)


### PR DESCRIPTION
## Summary
- Add Firebase Auth–powered GitHub SSO so users sign in with their GitHub account instead of pasting a PAT; the OAuth `accessToken` returned in the credential becomes the GitHub API token the rest of the app already uses.
- Add a Login view, gate every dashboard route on the Firebase auth observer in `App.tsx`, repurpose Disconnect → Sign Out in the toolbar, and strip the PAT input from Setup so it's just a repo picker.
- Move user profile docs from `userProfiles/{githubLogin}` to `userProfiles/{firebaseUid}` and tighten `firestore.rules` to require auth (per-user scoping on profiles, signed-in-only on story map layouts).

## Implementation notes
- `src/lib/auth.ts` wraps `signInWithPopup(GithubAuthProvider)` with `repo` + `project` scopes and caches the OAuth token in `localStorage['gh_token']` — Firebase only hands back the GitHub access token once (at sign-in), so the cache is what keeps the session usable across page refreshes per the acceptance criterion. The Firebase auth session itself persists automatically via the SDK's default IndexedDB persistence.
- `App.tsx` now goes through three states: `loading` → spinner, `signed-out` → `<Login />`, `signed-in` → either `<Setup />` (if no repo selected yet) or the dashboard. This satisfies the route-guard criterion without a router.
- `loadUserProfile`/`saveUserProfile` lost the `owner` parameter and read `auth.currentUser.uid` internally. **Migration impact:** old profile docs at `userProfiles/<github-login>` are not read after this change; user prefs (timeline granularity, kanban filter, personal details) will reset on first sign-in. The data still lives in Firestore if anyone wants to migrate it manually later.
- `firestore.rules` previously had `allow read, write: if true`. The new rules require auth on every doc and require `request.auth.uid == uid` on `userProfiles/{uid}`. `storyMaps/{repoKey}` requires auth but isn't per-user scoped — repo-level access is gated by the user actually having a working GitHub token for that repo, which the client enforces.
- The Settings → General tab still lets you paste a token/owner/repo manually as an escape hatch; not removed in this PR.

## Console setup that must be done before this works in prod (already confirmed done by you)
1. Firebase Console → Authentication → Sign-in method → GitHub → **Enable** and copy the auth handler URL.
2. GitHub → Developer settings → OAuth Apps → New OAuth App with that URL as the callback. Copy Client ID + Secret back into Firebase.
3. Firebase Auth → Settings → Authorized domains: add your hosting domain(s).
4. Deploy the updated `firestore.rules` (`firebase deploy --only firestore:rules`) — without this the app will write to the new schema but the old open rules remain in effect.

## Test plan
- [ ] Visit the app while signed-out → Login view appears, no dashboard tabs are reachable by direct URL.
- [ ] Click **Sign in with GitHub** → GitHub OAuth popup → after approval, app shows the repo picker (Setup view).
- [ ] Pick a repo → dashboard loads, issues + projects + milestones fetch successfully (token in use).
- [ ] Refresh the page → still signed in, still in the same repo, no popup.
- [ ] Cancel the OAuth popup → red error banner on the Login view; no console crash.
- [ ] Click the red Sign out button in the toolbar → Login view returns; localStorage `gh_token`/`gh_owner`/`gh_repo` cleared.
- [ ] After deploying `firestore.rules`, signed-out browser tab can no longer read `/storyMaps/*` or `/userProfiles/*` from the Firebase console emulator's "Rules playground" (sanity check).
- [ ] Set a timeline granularity, refresh — preference comes back (round-trip through `userProfiles/{uid}`).

Closes #3