### PR TITLE
feat: Gemini models dropdown for AI issue description (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Labels are created automatically on GitHub when you add them through the **User 
 - Real-time sync with GitHub Issues API
 - Resizable columns in both Grid and Kanban views (see below)
 - Describe with AI uses the user activity, the wave, the issue title, example issues, the code and additional instructions to create the issue's spec
+- **Gemini model selector** — choose the exact Gemini model to use for each AI generation request directly from the issue modal (see below)
 - Code with AI delegate issue implementation to a Claude Managed Agent (creates branch, writes code, opens PR)
 
 ## Read-only issue view
@@ -149,6 +150,29 @@ All values are stored in `localStorage` only.
 - **Build:** Vite
 
 ## Changelog
+
+### Gemini Models Dropdown (#74)
+
+Users can now select the exact Gemini model used for AI-assisted issue description generation without leaving the issue modal:
+
+- **`src/lib/gemini.ts`**
+  - Added `GEMINI_MODELS` constant — an exported `as const` array of the 8 supported models: `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3.1-flash-live-preview`.
+  - Changed `DEFAULT_GEMINI_MODEL` to `gemini-2.5-flash` (fast, production-ready default).
+  - Added optional `modelOverride` parameter to `generateDescription()` — when provided it takes precedence over the value stored in `localStorage`, so per-request model selection works without mutating global settings.
+
+- **`src/components/CreateIssueModal.tsx`**
+  - Added `geminiModel` state initialized from `loadGeminiSettings().model`.
+  - A `<select>` dropdown listing all 8 models from `GEMINI_MODELS` appears inline next to the **✦ Generate with AI** button when a Gemini API key is configured.
+  - The dropdown uses the same purple styling as the Generate button to maintain visual coherence.
+  - `handleGenerate` passes the selected model as the `modelOverride` argument to `generateDescription`.
+
+- **`src/components/EditIssueModal.tsx`**
+  - Same changes as `CreateIssueModal` — `geminiModel` state, inline model selector dropdown, and `modelOverride` passed to `generateDescription`.
+  - The dropdown appears in the **Description** tab toolbar alongside the Generate button.
+
+- **`src/components/SettingsView.tsx`**
+  - The free-text **Model** input in **Settings → Describing** has been replaced with a `<select>` dropdown populated from `GEMINI_MODELS`, giving a consistent experience between the settings page and the inline modal selector.
+  - Added a helper note explaining that the settings value is the default, which can be overridden per-request in the modal.
 
 ### Table View (#5)
 

--- a/src/components/CreateIssueModal.tsx
+++ b/src/components/CreateIssueModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
-import { generateDescription, loadGeminiSettings } from '../lib/gemini';
+import { generateDescription, loadGeminiSettings, GEMINI_MODELS } from '../lib/gemini';
 import type { IssueContext } from '../lib/gemini';
 import ImageAttacher, { type AttachedImage } from './ImageAttacher';
 
@@ -24,8 +24,11 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState('');
 
+  const geminiSettings = loadGeminiSettings();
+  const hasGeminiKey = Boolean(geminiSettings.apiKey);
+  const [geminiModel, setGeminiModel] = useState(geminiSettings.model);
+
   const openProjects = projects.filter((p) => !p.closed);
-  const hasGeminiKey = Boolean(loadGeminiSettings().apiKey);
 
   async function handleGenerate() {
     if (!title.trim()) { setError('Add a title before generating.'); return; }
@@ -40,7 +43,7 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
         waveName: wave?.title,
         waveDescription: wave?.description ?? undefined,
       };
-      const result = await generateDescription(token, owner, repo, title.trim(), body.trim(), context);
+      const result = await generateDescription(token, owner, repo, title.trim(), body.trim(), context, geminiModel);
       setBody(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Generation failed');
@@ -108,24 +111,36 @@ export default function CreateIssueModal({ defaultProjectId, defaultMilestoneNum
                 Description <span className="text-gray-400 font-normal">(optional)</span>
               </label>
               {hasGeminiKey && (
-                <button
-                  type="button"
-                  onClick={handleGenerate}
-                  disabled={generating || !title.trim()}
-                  className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-lg hover:bg-purple-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                >
-                  {generating ? (
-                    <>
-                      <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-                      </svg>
-                      Generating…
-                    </>
-                  ) : (
-                    <>✦ Generate with AI</>
-                  )}
-                </button>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={geminiModel}
+                    onChange={(e) => setGeminiModel(e.target.value)}
+                    className="text-xs border border-purple-200 rounded-lg px-2 py-1 text-purple-700 bg-purple-50 focus:outline-none focus:ring-2 focus:ring-purple-400 cursor-pointer"
+                    title="Select Gemini model"
+                  >
+                    {GEMINI_MODELS.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={handleGenerate}
+                    disabled={generating || !title.trim()}
+                    className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-lg hover:bg-purple-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {generating ? (
+                      <>
+                        <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                        </svg>
+                        Generating…
+                      </>
+                    ) : (
+                      <>✦ Generate with AI</>
+                    )}
+                  </button>
+                </div>
               )}
             </div>
             <textarea

--- a/src/components/EditIssueModal.tsx
+++ b/src/components/EditIssueModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, type RefObject } from 'react';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue } from '../types';
-import { generateDescription, loadGeminiSettings } from '../lib/gemini';
+import { generateDescription, loadGeminiSettings, GEMINI_MODELS } from '../lib/gemini';
 import type { IssueContext } from '../lib/gemini';
 import { fetchIssueImplementation, parseImagesFromBody } from '../lib/github';
 import ImageAttacher, { type AttachedImage } from './ImageAttacher';
@@ -205,6 +205,10 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
   const [error, setError] = useState('');
   const [generating, setGenerating] = useState(false);
 
+  // Gemini model selection
+  const geminiSettings = loadGeminiSettings();
+  const [geminiModel, setGeminiModel] = useState(geminiSettings.model);
+
   // AI coding
   const [aiLinks, setAiLinks] = useState<AiLinks>({});
   const [aiLinksLoading, setAiLinksLoading] = useState(false);
@@ -226,7 +230,7 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
   useEffect(() => () => { abortRef.current?.abort(); }, []);
 
   const openProjects = projects.filter((p) => !p.closed);
-  const hasGeminiKey = Boolean(loadGeminiSettings().apiKey);
+  const hasGeminiKey = Boolean(geminiSettings.apiKey);
   const anthropicSettings = loadAnthropicSettings();
   const hasAnthropicSettings = Boolean(
     anthropicSettings.apiKey &&
@@ -392,7 +396,7 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
         waveName: wave?.title,
         waveDescription: wave?.description ?? undefined,
       };
-      const result = await generateDescription(token, owner, repo, title.trim(), body.trim(), context);
+      const result = await generateDescription(token, owner, repo, title.trim(), body.trim(), context, geminiModel);
       setBody(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Generation failed');
@@ -513,14 +517,26 @@ export default function EditIssueModal({ issue, onClose, initialTab = 'descripti
               <div className="h-full flex flex-col">
                 <div className="flex justify-end mb-1">
                   {hasGeminiKey && (
-                    <button
-                      type="button"
-                      onClick={handleGenerate}
-                      disabled={generating || !title.trim()}
-                      className="flex items-center justify-center gap-1.5 w-36 px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-lg hover:bg-purple-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                    >
-                      {generating ? <><Spinner />Generating…</> : <>✦ Generate with AI</>}
-                    </button>
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={geminiModel}
+                        onChange={(e) => setGeminiModel(e.target.value)}
+                        className="text-xs border border-purple-200 rounded-lg px-2 py-1 text-purple-700 bg-purple-50 focus:outline-none focus:ring-2 focus:ring-purple-400 cursor-pointer"
+                        title="Select Gemini model"
+                      >
+                        {GEMINI_MODELS.map((m) => (
+                          <option key={m} value={m}>{m}</option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={handleGenerate}
+                        disabled={generating || !title.trim()}
+                        className="flex items-center justify-center gap-1.5 w-36 px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-lg hover:bg-purple-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                      >
+                        {generating ? <><Spinner />Generating…</> : <>✦ Generate with AI</>}
+                      </button>
+                    </div>
                   )}
                 </div>
                 <textarea

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAppStore } from '../store/appStore';
-import { loadGeminiSettings, saveGeminiSettings, testGeminiConnection, DEFAULT_GEMINI_MODEL } from '../lib/gemini';
+import { loadGeminiSettings, saveGeminiSettings, testGeminiConnection, DEFAULT_GEMINI_MODEL, GEMINI_MODELS } from '../lib/gemini';
 import { loadAnthropicSettings, saveAnthropicSettings, testAnthropicConnection } from '../lib/anthropic';
 import { loadUserProfile, saveUserProfile } from '../lib/firebase';
 
@@ -101,7 +101,7 @@ export default function SettingsView() {
   // Describing tab state
   const savedGemini = loadGeminiSettings();
   const [apiKey, setApiKey] = useState(savedGemini.apiKey);
-  const [model, setModel] = useState(savedGemini.model);
+  const [model, setModel] = useState(savedGemini.model || DEFAULT_GEMINI_MODEL);
   const [exampleNumbers, setExampleNumbers] = useState<number[]>(savedGemini.exampleIssueNumbers);
   const [extraInstructions, setExtraInstructions] = useState(savedGemini.extraInstructions);
   const [search, setSearch] = useState('');
@@ -348,17 +348,22 @@ export default function SettingsView() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Model</label>
-                <input
-                  type="text"
+                <label className="block text-sm font-medium text-gray-700 mb-1">Default Model</label>
+                <select
                   value={model}
                   onChange={(e) => {
                     setModel(e.target.value);
                     setLedState('idle');
                   }}
-                  placeholder={DEFAULT_GEMINI_MODEL}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
-                />
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white font-mono"
+                >
+                  {GEMINI_MODELS.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-400 mt-1">
+                  The default model used for AI generation. Can be overridden per-request in the issue modal.
+                </p>
               </div>
 
               <div>

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,5 +1,17 @@
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
-export const DEFAULT_GEMINI_MODEL = 'gemini-3.1-pro-preview';
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
+
+/** Supported Gemini models available for selection in the UI. */
+export const GEMINI_MODELS = [
+  'gemini-3.5-flash',
+  'gemini-3.1-pro-preview',
+  'gemini-3.1-flash-lite',
+  'gemini-3-flash-preview',
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-2.5-flash-lite',
+  'gemini-3.1-flash-live-preview',
+] as const;
 
 export interface GeminiSettings {
   apiKey: string;
@@ -56,9 +68,11 @@ export async function generateDescription(
   title: string,
   existingBody: string,
   context: IssueContext = {},
+  modelOverride?: string,
 ): Promise<string> {
-  const { apiKey, model, exampleIssueNumbers, extraInstructions } = loadGeminiSettings();
+  const { apiKey, model: savedModel, exampleIssueNumbers, extraInstructions } = loadGeminiSettings();
   if (!apiKey) throw new Error('No Gemini API key configured. Add one in Settings.');
+  const model = modelOverride ?? savedModel;
 
   // Fetch README
   let readme = '';


### PR DESCRIPTION
## Summary

Implements a Gemini model selector dropdown in the AI issue description UI, allowing users to choose the exact model powering their issue generation and modification tasks — without leaving the modal.

## Changes

### `src/lib/gemini.ts`
- Added `GEMINI_MODELS` — an exported `as const` array of the 8 supported models specified in the issue:
  `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3.1-flash-live-preview`
- Changed `DEFAULT_GEMINI_MODEL` to `gemini-2.5-flash` (fast, stable production model)
- Added optional `modelOverride?: string` parameter to `generateDescription()` — takes precedence over the localStorage default when provided

### `src/components/CreateIssueModal.tsx`
- Added `geminiModel` state initialized from `loadGeminiSettings().model`
- Added a `<select>` dropdown listing all 8 models (styled in purple to match the Generate button) shown inline when Gemini is configured
- `handleGenerate` passes `geminiModel` as `modelOverride` to `generateDescription`

### `src/components/EditIssueModal.tsx`
- Same model-selector dropdown and state as `CreateIssueModal`, placed in the Description tab toolbar alongside the Generate button

### `src/components/SettingsView.tsx`
- Replaced the free-text **Model** input in **Settings → Describing** with a `<select>` dropdown using `GEMINI_MODELS`
- Added helper note clarifying that the settings value is the default, overridable per-request in the modal

### `README.md`
- Added changelog entry documenting all changes for this feature

## Acceptance Criteria ✅

- [x] Dropdown selector is visible in both the Create Issue and Edit Issue modals when Gemini is configured
- [x] Dropdown shows all 8 specified Gemini models
- [x] Default selection is `gemini-2.5-flash` (sensible, fast model)
- [x] Changing the dropdown updates component state (`geminiModel`)
- [x] The selected model ID is sent in the Gemini API request payload via `modelOverride`
- [x] UI is clean and fits existing modal styling (purple theme, consistent with Generate button)

Closes #74