### PR TITLE
Hide waves with no open issues

### DIFF
--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -108,9 +108,15 @@ export default function KanbanView() {
             className="text-sm border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-400 disabled:opacity-50"
           >
             <option value="">All Waves</option>
-            {milestones.map((m) => (
-              <option key={m.number} value={m.number}>{m.title}</option>
-            ))}
+            {milestones
+              .filter((m) =>
+                kanbanShowClosedIssues ||
+                m.number === kanbanMilestoneNumber ||
+                issues.some((i) => i.state === 'open' && i.milestone?.number === m.number),
+              )
+              .map((m) => (
+                <option key={m.number} value={m.number}>{m.title}</option>
+              ))}
           </select>
         </div>
       )}

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -160,8 +160,11 @@ export default function StoryMap() {
   const cols = sortedProjects(projects, layout.userActivityOrder).filter((p) =>
     layout.includedProjects ? layout.includedProjects.includes(p.number) : !p.closed
   );
-  const orderedMilestones = sortedMilestones(milestones, layout.milestoneOrder);
   const visibleIssues = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
+  const orderedMilestones = sortedMilestones(milestones, layout.milestoneOrder).filter(
+    (m) => showClosedIssues || visibleIssues.some((i) => i.milestone?.number === m.number),
+  );
+  const showNoWaveRow = showClosedIssues || visibleIssues.some((i) => i.milestone === null);
 
   function cellIssues(projectId: string, milestoneNumber: number | null): GitHubIssue[] {
     const inProject = new Set(projectIssues[projectId] ?? []);
@@ -415,6 +418,7 @@ export default function StoryMap() {
                   {provided.placeholder}
 
                   {/* "No Wave" row — always last, not draggable */}
+                  {showNoWaveRow && (
                   <tr key="no-wave">
                     <th className="sticky left-0 z-10 bg-gray-50 border border-gray-200 px-2 py-2 text-xs font-semibold text-gray-500 text-right align-top pt-3 w-[200px] min-w-[200px] max-w-[200px]">
                       {addingWave ? (
@@ -470,6 +474,7 @@ export default function StoryMap() {
                       />
                     </td>
                   </tr>
+                  )}
                 </tbody>
               )}
             </Droppable>


### PR DESCRIPTION
## Summary

- When the **Hide Closed Issues** filter is active, milestone rows in the Grid view that have no open issues are removed from the layout. The "No Wave" row is also hidden if no open issue lacks a milestone.
- The Kanban view's **Wave** dropdown filters out milestone options that have no open issues while the filter is on, so users can't pick a wave that would render an empty board. The currently selected wave is kept visible so the controlled `<select>` doesn't end up in an invalid state.
- Toggling the filter immediately updates wave visibility — no refresh, no manual state reset.

## Implementation notes

- **`src/components/StoryMap.tsx`** — moved `visibleIssues` above `orderedMilestones` and chained a `.filter((m) => showClosedIssues || visibleIssues.some(...))` onto the milestone list. Added a `showNoWaveRow` boolean using the same predicate against `milestone === null` and wrapped the existing "No Wave" `<tr>` in a `{showNoWaveRow && (...)}` block. No drag-and-drop rewiring needed — the row was already not part of the `Droppable type="ROW"`.
- **`src/components/KanbanView.tsx`** — the actual Kanban view groups by user activity, not by wave (the README mentions wave swimlanes but the code uses a single-wave filter dropdown instead). The closest analog to "hiding waves with no open issues" is filtering the options in that dropdown. I kept the currently selected milestone in the list regardless of its open-issue count to avoid an invalid `<select>` value if a wave gets emptied while it's selected.
- No new dependencies. No store changes — both filters key off the existing `showClosedIssues` / `kanbanShowClosedIssues` state.

## Test plan

- [ ] Grid view, **Hide Closed Issues OFF** — every wave with a row in the milestone order is visible (baseline).
- [ ] Grid view, **Hide Closed Issues ON** — waves whose issues are all closed disappear from the rows; waves with at least one open issue stay; toggling the filter back to OFF restores them instantly.
- [ ] Grid view, **No Wave row** — when at least one open issue has no milestone, the row is visible; when all such issues are closed (or there are none), the row is hidden under the filter; the **+ New Wave** button still appears when waves come back.
- [ ] Grid view, **Drag-and-drop** still works after a wave row appears/disappears (no stale indexes in the `Droppable`).
- [ ] Kanban view, **Wave dropdown, Hide Closed Issues OFF** — every milestone in `milestones` is listed.
- [ ] Kanban view, **Wave dropdown, Hide Closed Issues ON** — only milestones with at least one open issue are listed, *plus* the currently selected one if it was already chosen before the filter hid it.
- [ ] Kanban view — switching the wave filter while **Hide Closed Issues** is active still loads the right cards and doesn't break the controlled select.

Closes #76