### PR TITLE
Enable whitelisting user activities

### DIFF
--- a/src/components/KanbanView.tsx
+++ b/src/components/KanbanView.tsx
@@ -44,7 +44,7 @@ function kanbanColKey(status: string): string {
 
 export default function KanbanView() {
   const {
-    issues, layout, kanbanShowClosedIssues,
+    issues, layout, kanbanShowClosedIssues, linkedProjectIds,
     moveIssueInKanbanByProject, columnWidths, setColumnWidth,
     projects, projectIssues, kanbanMilestoneNumber, setKanbanMilestone,
     kanbanStatusColumns, kanbanIssueStatuses, milestones, loading,
@@ -55,9 +55,9 @@ export default function KanbanView() {
   const cols = [...kanbanStatusColumns];
   const colK = (status: string) => columnWidths[kanbanColKey(status)] ?? KANBAN_DEFAULT_WIDTH;
 
-  const openProjects = projects.filter((p) => !p.closed).filter((p) =>
-    layout.includedProjects ? layout.includedProjects.includes(p.number) : !p.closed
-  );
+  const openProjects = projects
+    .filter((p) => !p.closed)
+    .filter((p) => linkedProjectIds.includes(p.id));
   // null sentinel = "No User Activity" row — always last
   const groups: (GitHubProject | null)[] = [...sortedProjects(openProjects, layout.userActivityOrder), null];
 

--- a/src/components/RoadmapView.tsx
+++ b/src/components/RoadmapView.tsx
@@ -209,14 +209,14 @@ function sortedMilestones(milestones: GitHubMilestone[], order: number[]): GitHu
 
 export default function RoadmapView() {
   const {
-    issues, projects, milestones, projectIssues, layout,
+    issues, projects, milestones, projectIssues, layout, linkedProjectIds,
     kanbanIssueStatuses, kanbanStatusColors, kanbanStatusColumns,
   } = useAppStore();
 
   const [cellMode, setCellMode] = useState<CellMode>('donut');
 
   const rows = sortedProjects(projects, layout.userActivityOrder).filter((p) =>
-    layout.includedProjects ? layout.includedProjects.includes(p.number) : !p.closed
+    linkedProjectIds.includes(p.id),
   );
   const cols = sortedMilestones(milestones, layout.milestoneOrder ?? []);
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -54,6 +54,9 @@ export default function SettingsView() {
     owner,
     repo,
     issues,
+    projects,
+    linkedProjectIds,
+    setProjectLinked,
     setCredentials,
     fetchIssues,
     fetchLabels,
@@ -67,6 +70,7 @@ export default function SettingsView() {
   // General tab state
   const [ghOwner, setGhOwner] = useState(owner);
   const [ghRepo, setGhRepo] = useState(repo);
+  const [whitelistSearch, setWhitelistSearch] = useState('');
 
   // User details state
   const [address, setAddress] = useState('');
@@ -238,6 +242,67 @@ export default function SettingsView() {
                   Layout data (user activity order, wave order, story positions) is automatically synced to
                   Firestore when available. No configuration required.
                 </p>
+              </div>
+
+              <div className="border-t border-gray-200 pt-6">
+                <div className="flex items-baseline justify-between mb-1">
+                  <h2 className="text-base font-semibold text-gray-900">User Activity Whitelist</h2>
+                  <span className="text-xs text-gray-400 font-mono truncate ml-3">{owner}/{repo}</span>
+                </div>
+                <p className="text-sm text-gray-500 mb-3">
+                  Check a project to link it to this repository. Only linked projects appear in the Story Map, Kanban, and Roadmap views, and changes persist on GitHub.
+                </p>
+                {(() => {
+                  const linkedSet = new Set(linkedProjectIds);
+                  const linkedCount = projects.filter((p) => linkedSet.has(p.id)).length;
+                  const filtered = projects.filter((p) =>
+                    p.title.toLowerCase().includes(whitelistSearch.toLowerCase()),
+                  );
+                  return (
+                    <>
+                      <div className="flex items-center justify-between mb-2 gap-2">
+                        <input
+                          type="text"
+                          value={whitelistSearch}
+                          onChange={(e) => setWhitelistSearch(e.target.value)}
+                          placeholder="Search user activities…"
+                          className="flex-1 border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                      </div>
+                      <div className="text-xs text-gray-400 mb-2">
+                        {linkedCount} of {projects.length} linked to {repo}
+                      </div>
+                      <ul className="border border-gray-200 rounded-lg divide-y divide-gray-100 max-h-72 overflow-y-auto bg-white">
+                        {projects.length === 0 ? (
+                          <li className="px-3 py-3 text-sm text-gray-400 italic">No user activities found for this organization.</li>
+                        ) : filtered.length === 0 ? (
+                          <li className="px-3 py-3 text-sm text-gray-400 italic">No matches.</li>
+                        ) : (
+                          filtered.map((p) => {
+                            const checked = linkedSet.has(p.id);
+                            return (
+                              <li key={p.id}>
+                                <label className="w-full flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-50">
+                                  <input
+                                    type="checkbox"
+                                    checked={checked}
+                                    onChange={() => setProjectLinked(p.id, !checked)}
+                                    className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                                  />
+                                  <span className="text-gray-400 tabular-nums shrink-0 text-xs font-mono">#{p.number}</span>
+                                  <span className="truncate text-gray-800">{p.title}</span>
+                                  {p.closed && (
+                                    <span className="ml-auto px-1.5 py-0.5 rounded text-xs bg-gray-100 text-gray-500 shrink-0">closed</span>
+                                  )}
+                                </label>
+                              </li>
+                            );
+                          })
+                        )}
+                      </ul>
+                    </>
+                  );
+                })()}
               </div>
 
               <div className="border-t border-gray-200 pt-6">

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -102,7 +102,7 @@ function CardCell({ droppableId, items, onAdd, addColor = 'blue' }: CardCellProp
 
 export default function StoryMap() {
   const {
-    issues, projects, projectIssues, milestones, layout,
+    issues, projects, projectIssues, milestones, layout, linkedProjectIds,
     reorderProjects, reorderMilestones, moveIssueInGrid, showClosedIssues,
     createProject, createMilestone,
     columnWidths, setColumnWidth,
@@ -158,7 +158,7 @@ export default function StoryMap() {
   }
 
   const cols = sortedProjects(projects, layout.userActivityOrder).filter((p) =>
-    layout.includedProjects ? layout.includedProjects.includes(p.number) : !p.closed
+    linkedProjectIds.includes(p.id),
   );
   const visibleIssues = showClosedIssues ? issues : issues.filter((i) => i.state === 'open');
   const orderedMilestones = sortedMilestones(milestones, layout.milestoneOrder).filter(

--- a/src/components/UserActivitiesView.tsx
+++ b/src/components/UserActivitiesView.tsx
@@ -77,7 +77,7 @@ function SidebarItem({
 }
 
 export default function UserActivitiesView() {
-  const { projects, issues, projectIssues, createProject, updateProject, deleteProject, layout, toggleProjectInclusion, repo } = useAppStore();
+  const { projects, issues, projectIssues, createProject, updateProject, deleteProject, linkedProjectIds, setProjectLinked, repo } = useAppStore();
   const [selectedId, setSelectedId] = useState<string | null>(
     projects.length > 0 ? projects[0].id : null,
   );
@@ -182,9 +182,7 @@ export default function UserActivitiesView() {
             <p className="px-3 py-3 text-xs text-gray-400 italic">No user activities yet</p>
           ) : (
             projects.map((p) => {
-              const isIncluded = layout.includedProjects
-                ? layout.includedProjects.includes(p.number)
-                : !p.closed;
+              const isIncluded = linkedProjectIds.includes(p.id);
               return (
                 <SidebarItem
                   key={p.id}
@@ -194,7 +192,7 @@ export default function UserActivitiesView() {
                   openCount={issueCounts[p.id]?.open ?? 0}
                   closedCount={issueCounts[p.id]?.closed ?? 0}
                   isIncluded={isIncluded}
-                  onToggleInclusion={() => toggleProjectInclusion(p.number)}
+                  onToggleInclusion={() => setProjectLinked(p.id, !isIncluded)}
                 />
               );
             })
@@ -326,8 +324,8 @@ export default function UserActivitiesView() {
                     <label className="relative inline-flex items-center cursor-pointer">
                       <input
                         type="checkbox"
-                        checked={layout.includedProjects ? layout.includedProjects.includes(selected.number) : !selected.closed}
-                        onChange={() => toggleProjectInclusion(selected.number)}
+                        checked={linkedProjectIds.includes(selected.id)}
+                        onChange={() => setProjectLinked(selected.id, !linkedProjectIds.includes(selected.id))}
                         className="sr-only peer"
                       />
                       <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600"></div>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -43,6 +43,10 @@ interface AppState {
   kanbanItemIds: Record<number, string>;
   /** status option name → GitHub color enum string (e.g. "YELLOW", "GREEN"). */
   kanbanStatusColors: Record<string, string>;
+  /** GraphQL node ID for the currently selected repository, used to (un)link projects. */
+  repositoryId: string | null;
+  /** GraphQL node IDs of org projects currently linked to the active repository. */
+  linkedProjectIds: string[];
 
   setCredentials: (owner: string, repo: string) => void;
   signInWithGithub: () => Promise<void>;
@@ -118,7 +122,8 @@ interface AppState {
     fromProjectId: string | null,
     toProjectId: string | null,
   ) => Promise<void>;
-  toggleProjectInclusion: (projectNumber: number) => Promise<void>;
+  /** Link or unlink a GitHub Project from the active repository. */
+  setProjectLinked: (projectId: string, linked: boolean) => Promise<void>;
 }
 
 const emptyLayout: StoryMapLayout = { userActivityOrder: [], milestoneOrder: [], storyOrder: { backlog: [] } };
@@ -140,26 +145,6 @@ async function gql<T>(
     throw new Error(`${message}${location}`);
   }
   return json.data as T;
-}
-
-function includedProjectsKey(owner: string, repo: string): string {
-  return `included_projects_${owner}__${repo}`;
-}
-
-function loadIncludedProjects(owner: string, repo: string): number[] | undefined {
-  if (!owner || !repo) return undefined;
-  const raw = localStorage.getItem(includedProjectsKey(owner, repo));
-  if (!raw) return undefined;
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed) && parsed.every((n) => typeof n === 'number')) return parsed;
-  } catch { /* fall through */ }
-  return undefined;
-}
-
-function saveIncludedProjects(owner: string, repo: string, list: number[]): void {
-  if (!owner || !repo) return;
-  localStorage.setItem(includedProjectsKey(owner, repo), JSON.stringify(list));
 }
 
 async function ensureLabel(
@@ -203,11 +188,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   kanbanProjectStatusFields: {},
   kanbanItemIds: {},
   kanbanStatusColors: {},
+  repositoryId: null,
+  linkedProjectIds: [],
 
   setCredentials: (owner, repo) => {
     localStorage.setItem('gh_owner', owner);
     localStorage.setItem('gh_repo', repo);
-    set({ owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {} });
+    set({ owner, repo, issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {}, repositoryId: null, linkedProjectIds: [] });
   },
 
   signInWithGithub: async () => {
@@ -235,6 +222,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         projects: [], projectIssues: {}, kanbanMilestoneNumber: null,
         kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {},
         kanbanItemIds: {}, kanbanStatusColors: {},
+        repositoryId: null, linkedProjectIds: [],
       });
     }
   },
@@ -258,7 +246,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     localStorage.removeItem('gh_token');
     localStorage.removeItem('gh_owner');
     localStorage.removeItem('gh_repo');
-    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {} });
+    set({ token: '', owner: '', repo: '', issues: [], layout: emptyLayout, error: null, milestones: [], statusLabels: [], projects: [], projectIssues: {}, kanbanMilestoneNumber: null, kanbanStatusColumns: [], kanbanIssueStatuses: {}, kanbanProjectStatusFields: {}, kanbanItemIds: {}, kanbanStatusColors: {}, repositoryId: null, linkedProjectIds: [] });
   },
 
   setView: (view) => set({ view }),
@@ -491,9 +479,6 @@ export const useAppStore = create<AppState>((set, get) => ({
         }
       }
 
-      const cachedIncluded = loadIncludedProjects(owner, repo);
-      if (cachedIncluded) layout = { ...layout, includedProjects: cachedIncluded };
-
       set({ issues: allItems, layout, loading: false });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch issues';
@@ -651,8 +636,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     const data = await gql<{
       repositoryOwner: { projectsV2?: { nodes: ProjectNode[] } } | null;
+      repository: { id: string; projectsV2: { nodes: Array<{ id: string }> } } | null;
     }>(token, `
-      query($login: String!) {
+      query($login: String!, $owner: String!, $repo: String!) {
         repositoryOwner(login: $login) {
           ... on User {
             projectsV2(first: 50) {
@@ -671,8 +657,12 @@ export const useAppStore = create<AppState>((set, get) => ({
             }
           }
         }
+        repository(owner: $owner, name: $repo) {
+          id
+          projectsV2(first: 50) { nodes { id } }
+        }
       }
-    `, { login: owner });
+    `, { login: owner, owner, repo });
 
     const repoFullName = `${owner}/${repo}`;
     const nodes = data.repositoryOwner?.projectsV2?.nodes ?? [];
@@ -687,6 +677,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         .map((c) => c.number);
     }
 
+    const repositoryId = data.repository?.id ?? null;
+    const linkedProjectIds = (data.repository?.projectsV2.nodes ?? []).map((n) => n.id);
+
     // Sync userActivityOrder with current project numbers (preserving saved order, appending new)
     const projectNumbers = projects.map((p) => p.number);
     const preserved = layout.userActivityOrder.filter((n) => projectNumbers.includes(n));
@@ -697,10 +690,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     if (orderChanged) {
       const newLayout = { ...layout, userActivityOrder: newUserActivityOrder };
-      set({ projects, projectIssues, layout: newLayout });
+      set({ projects, projectIssues, layout: newLayout, repositoryId, linkedProjectIds });
       saveLayout(owner, repo, newLayout).catch(() => { /* offline */ });
     } else {
-      set({ projects, projectIssues });
+      set({ projects, projectIssues, repositoryId, linkedProjectIds });
     }
   },
 
@@ -816,7 +809,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     `, { projectId: project.id, repositoryId });
 
-    set({ projects: [project, ...projects] });
+    const { linkedProjectIds } = get();
+    set({
+      projects: [project, ...projects],
+      linkedProjectIds: linkedProjectIds.includes(project.id) ? linkedProjectIds : [...linkedProjectIds, project.id],
+    });
   },
 
   updateProject: async (id, title, description) => {
@@ -836,7 +833,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   deleteProject: async (id) => {
-    const { token, projects } = get();
+    const { token, projects, linkedProjectIds } = get();
     await gql(token, `
       mutation($projectId: ID!) {
         deleteProjectV2(input: { projectId: $projectId }) {
@@ -844,7 +841,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         }
       }
     `, { projectId: id });
-    set({ projects: projects.filter((p) => p.id !== id) });
+    set({
+      projects: projects.filter((p) => p.id !== id),
+      linkedProjectIds: linkedProjectIds.filter((pid) => pid !== id),
+    });
   },
 
   reorderProjects: (fromIndex, toIndex) => {
@@ -1202,22 +1202,37 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  toggleProjectInclusion: async (projectNumber) => {
-    const { layout, owner, repo, projects } = get();
-    const currentIncluded = layout.includedProjects ?? projects.filter(p => !p.closed).map(p => p.number);
-    let nextIncluded: number[];
-    if (currentIncluded.includes(projectNumber)) {
-      nextIncluded = currentIncluded.filter((n) => n !== projectNumber);
-    } else {
-      nextIncluded = [...currentIncluded, projectNumber];
-    }
-    const newLayout = { ...layout, includedProjects: nextIncluded };
-    set({ layout: newLayout });
-    saveIncludedProjects(owner, repo, nextIncluded);
+  setProjectLinked: async (projectId, linked) => {
+    const { token, repositoryId, linkedProjectIds } = get();
+    if (!token || !repositoryId) return;
+
+    const snapshot = linkedProjectIds;
+    const nextLinked = linked
+      ? (linkedProjectIds.includes(projectId) ? linkedProjectIds : [...linkedProjectIds, projectId])
+      : linkedProjectIds.filter((id) => id !== projectId);
+    set({ linkedProjectIds: nextLinked });
+
     try {
-      await saveLayout(owner, repo, newLayout);
+      if (linked) {
+        await gql(token, `
+          mutation($projectId: ID!, $repositoryId: ID!) {
+            linkProjectV2ToRepository(input: { projectId: $projectId, repositoryId: $repositoryId }) {
+              repository { id }
+            }
+          }
+        `, { projectId, repositoryId });
+      } else {
+        await gql(token, `
+          mutation($projectId: ID!, $repositoryId: ID!) {
+            unlinkProjectV2FromRepository(input: { projectId: $projectId, repositoryId: $repositoryId }) {
+              repository { id }
+            }
+          }
+        `, { projectId, repositoryId });
+      }
     } catch (err) {
-      console.warn('Failed to persist layout change to Firebase', err);
+      set({ linkedProjectIds: snapshot });
+      throw err;
     }
   },
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,8 +39,6 @@ export interface StoryMapLayout {
   storyOrder: Record<string, number[]>;
   /** Wave (milestone) start/end dates for the Timeline view, keyed by milestone number. */
   waveDates?: Record<number, { start: string; end: string }>;
-  /** The numbers of projects that are included in this repo's story map. */
-  includedProjects?: number[];
 }
 
 export interface GitHubProject {


### PR DESCRIPTION
## Summary
- Whitelist is now the GitHub project↔repository link itself — the Settings checkbox calls `linkProjectV2ToRepository` / `unlinkProjectV2FromRepository`, so the choice is persisted on GitHub and survives reloads without any localStorage cache.
- Story Map, Kanban, Roadmap, and the User Activities sidebar all filter columns/rows by the linked project set for the active repo.
- Added a `User Activity Whitelist` section to Settings → General with a searchable list of every org project and a "X of Y linked to {repo}" counter.

## Implementation notes
- `fetchProjects` now also queries `repository(owner, name) { id projectsV2 { nodes { id } } }` and stores `repositoryId` + `linkedProjectIds` in the Zustand store.
- New action `setProjectLinked(projectId, linked)` performs the link/unlink mutation, optimistically updating state and rolling back on failure.
- Removed the prior `layout.includedProjects` field, `toggleProjectInclusion`, `setIncludedProjects`, and the localStorage `included_projects_*` cache — they're obsolete now that GitHub is the source of truth.
- `createProject` (which already links the new project to the active repo) and `deleteProject` now keep `linkedProjectIds` in sync.
- The User Activities tab still has the in-place sidebar checkmark + detail toggle; they share the new action.

## Test plan
- [ ] Open Settings → General → "User Activity Whitelist", uncheck a project, refresh the page → it stays unchecked.
- [ ] Verify the same project disappeared from Story Map, Kanban, and Roadmap views immediately (no refresh).
- [ ] Re-check the project → it reappears in all three views and the change is reflected on GitHub (Project → Settings → Linked repositories).
- [ ] Toggle a project in the User Activities tab (sidebar checkmark + detail toggle) → state matches the Settings list.
- [ ] Search filter narrows the whitelist list correctly.
- [ ] Create a new user activity → it appears as linked (checked) in the whitelist.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)