### PR TITLE
feat: Notion-style UI redesign

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,9 +32,6 @@ export default function App() {
       try {
         const status = await getUserKeyStatus();
         if (!status.github) {
-          // Firebase says signed in, but no GitHub token in Firestore —
-          // user needs to re-auth to refresh it (e.g., after this rollout
-          // or after a manual delete).
           setAuthSignedOut();
           return;
         }
@@ -59,8 +56,8 @@ export default function App() {
 
   if (authStatus === 'loading') {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-400 text-sm">Loading…</div>
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--n-sidebar)' }}>
+        <div className="text-sm" style={{ color: 'var(--n-text-3)' }}>Loading…</div>
       </div>
     );
   }
@@ -70,36 +67,40 @@ export default function App() {
   if (!isConfigured) return <Setup />;
 
   return (
-    <div className="h-screen flex flex-col bg-gray-50 overflow-hidden">
+    <div className="h-screen flex overflow-hidden" style={{ background: 'var(--n-bg)' }}>
+      {/* Left sidebar navigation */}
       <Header />
 
-      {loading && (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-gray-400 text-sm">Loading issues…</div>
-        </div>
-      )}
-
-      {!loading && error && (
-        <div className="flex-1 flex items-center justify-center p-8">
-          <div className="bg-red-50 border border-red-200 rounded-xl px-6 py-4 text-red-700 text-sm max-w-md text-center">
-            <p className="font-medium mb-1">Failed to load issues</p>
-            <p className="text-red-500">{error}</p>
+      {/* Main content area */}
+      <main className="flex-1 flex flex-col overflow-hidden">
+        {loading && (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-sm" style={{ color: 'var(--n-text-3)' }}>Loading issues…</div>
           </div>
-        </div>
-      )}
+        )}
 
-      {!loading && !error && (
-        <div className="flex-1 overflow-hidden flex">
-          {view === 'grid' && <StoryMap />}
-          {view === 'kanban' && <KanbanView />}
-          {view === 'table' && <TableView />}
-          {view === 'waves' && <WavesView />}
-          {view === 'user-activities' && <UserActivitiesView />}
-          {view === 'roadmap' && <RoadmapView />}
-          {view === 'timeline' && <TimelineView />}
-          {view === 'settings' && <SettingsView />}
-        </div>
-      )}
+        {!loading && error && (
+          <div className="flex-1 flex items-center justify-center p-8">
+            <div className="rounded-lg px-5 py-4 text-sm max-w-md text-center" style={{ background: '#FFF2F2', border: '1px solid #FFD5D5', color: '#E03E3E' }}>
+              <p className="font-medium mb-1">Failed to load issues</p>
+              <p style={{ color: '#D44C47' }}>{error}</p>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <div className="flex-1 overflow-hidden flex">
+            {view === 'grid' && <StoryMap />}
+            {view === 'kanban' && <KanbanView />}
+            {view === 'table' && <TableView />}
+            {view === 'waves' && <WavesView />}
+            {view === 'user-activities' && <UserActivitiesView />}
+            {view === 'roadmap' && <RoadmapView />}
+            {view === 'timeline' && <TimelineView />}
+            {view === 'settings' && <SettingsView />}
+          </div>
+        )}
+      </main>
     </div>
   );
 }

--- a/src/components/ChangeRepoModal.tsx
+++ b/src/components/ChangeRepoModal.tsx
@@ -8,8 +8,8 @@ interface Repo {
   private: boolean;
 }
 
-export default function Setup() {
-  const { setCredentials, signOut, fetchIssues, fetchLabels, fetchProjects, fetchMilestones } = useAppStore();
+export default function ChangeRepoModal({ onClose }: { onClose: () => void }) {
+  const { setCredentials, fetchIssues, fetchLabels, fetchProjects, fetchMilestones } = useAppStore();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [fetchingRepos, setFetchingRepos] = useState(false);
   const [repoError, setRepoError] = useState('');
@@ -29,7 +29,7 @@ export default function Setup() {
             `/github-api/user/repos?per_page=100&page=${page}&sort=updated`,
             { headers: { Authorization: `Bearer ${idToken}`, Accept: 'application/vnd.github.v3+json' } },
           );
-          if (!res.ok) throw new Error('GitHub returned ' + res.status + ' — your session may have expired. Sign out and back in.');
+          if (!res.ok) throw new Error('GitHub returned ' + res.status + ' — your session may have expired.');
           const data: Repo[] = await res.json();
           all.push(...data);
           if (data.length < 100) break;
@@ -50,6 +50,7 @@ export default function Setup() {
     setConnecting(true);
     await Promise.all([fetchIssues(), fetchLabels(), fetchProjects(), fetchMilestones()]);
     setConnecting(false);
+    onClose();
   }
 
   const filtered = repos.filter((r) =>
@@ -57,37 +58,35 @@ export default function Setup() {
   );
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: 'var(--n-sidebar)' }}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.4)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
       <div
-        className="w-full max-w-md p-8 rounded-xl"
+        className="w-full max-w-md p-8 rounded-xl mx-4"
         style={{ background: 'var(--n-bg)', border: '1px solid var(--n-border)', boxShadow: 'var(--n-shadow-lg)' }}
       >
         <div className="flex items-start justify-between mb-1">
-          <div className="flex items-center gap-3 mb-1">
-            <div
-              className="w-8 h-8 rounded-lg flex items-center justify-center text-white font-bold text-sm"
-              style={{ background: 'var(--n-blue)' }}
-            >
-              G
-            </div>
-            <h1 className="text-base font-semibold" style={{ color: 'var(--n-text)' }}>
-              Select a repository
-            </h1>
-          </div>
+          <h2 className="text-base font-semibold" style={{ color: 'var(--n-text)' }}>
+            Change repository
+          </h2>
           <button
             type="button"
-            onClick={() => { void signOut(); }}
-            className="text-xs underline"
+            onClick={onClose}
+            className="p-1 rounded-md transition-colors"
             style={{ color: 'var(--n-text-3)' }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--n-text-2)'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--n-text-3)'; }}
+            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover)'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-3)'; }}
           >
-            Sign out
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
           </button>
         </div>
 
         <p className="text-sm mb-6" style={{ color: 'var(--n-text-2)' }}>
-          Pick the repository whose issues you want to visualize.
+          Pick a repository to switch to.
         </p>
 
         <div className="space-y-3">
@@ -106,6 +105,7 @@ export default function Setup() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Filter repositories…"
+                autoFocus
                 className="w-full px-3 py-2 text-sm rounded-md mb-2 outline-none transition-all"
                 style={{
                   border: '1px solid var(--n-border)',
@@ -147,7 +147,7 @@ export default function Setup() {
                     </button>
                   </li>
                 ))}
-                {filtered.length === 0 && (
+                {filtered.length === 0 && !fetchingRepos && (
                   <li className="px-3 py-3 text-sm" style={{ color: 'var(--n-text-3)' }}>
                     No repositories match.
                   </li>
@@ -160,10 +160,6 @@ export default function Setup() {
             <p className="text-sm text-center" style={{ color: 'var(--n-text-3)' }}>Connecting…</p>
           )}
         </div>
-
-        <p className="text-xs mt-6" style={{ color: 'var(--n-text-3)' }}>
-          GitHub Projects become User Activity columns. Milestones become rows. Drag issues between cells to organise your story map.
-        </p>
       </div>
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,128 +1,293 @@
 import { useState } from 'react';
 import { useAppStore } from '../store/appStore';
 import CreateIssueModal from './CreateIssueModal';
+import ChangeRepoModal from './ChangeRepoModal';
 
-const VIEW_LABELS: Record<string, string> = {
-  grid: 'Story Map',
-  kanban: 'Kanban',
-  table: 'Table',
-  waves: 'Waves',
-  'user-activities': 'User Activities',
-  roadmap: 'Roadmap',
-  timeline: 'Timeline',
-  settings: 'Settings',
-};
+type View = 'grid' | 'kanban' | 'table' | 'waves' | 'user-activities' | 'roadmap' | 'timeline' | 'settings';
+
+const NAV_ITEMS: { view: View; label: string; icon: React.ReactNode }[] = [
+  {
+    view: 'grid',
+    label: 'Story Map',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+      </svg>
+    ),
+  },
+  {
+    view: 'kanban',
+    label: 'Board',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M2 4a1 1 0 011-1h3a1 1 0 011 1v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4zM8 4a1 1 0 011-1h3a1 1 0 011 1v7a1 1 0 01-1 1H9a1 1 0 01-1-1V4zM15 4a1 1 0 00-1 1v4a1 1 0 001 1h2a1 1 0 001-1V5a1 1 0 00-1-1h-2z" />
+      </svg>
+    ),
+  },
+  {
+    view: 'table',
+    label: 'Table',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M5 4a3 3 0 00-3 3v6a3 3 0 003 3h10a3 3 0 003-3V7a3 3 0 00-3-3H5zm-1 9v-1h5v2H5a1 1 0 01-1-1zm7 1h4a1 1 0 001-1v-1h-5v2zm0-4h5V8h-5v2zM9 8H4v2h5V8z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+  {
+    view: 'timeline',
+    label: 'Timeline',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+  {
+    view: 'roadmap',
+    label: 'Roadmap',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M12 1.586l-4 4v12.828l4-4V1.586zM3.707 3.293A1 1 0 002 4v10a1 1 0 00.293.707L6 18.414V5.586L3.707 3.293zM17.707 5.293L14 1.586v12.828l2.293 2.293A1 1 0 0018 16V6a1 1 0 00-.293-.707z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+  {
+    view: 'waves',
+    label: 'Waves',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z" />
+      </svg>
+    ),
+  },
+  {
+    view: 'user-activities',
+    label: 'Activities',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
+      </svg>
+    ),
+  },
+  {
+    view: 'settings',
+    label: 'Settings',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+];
 
 export default function Header() {
-  const { owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses, signOut, loading, view, setView, showClosedIssues, toggleShowClosedIssues, kanbanShowClosedIssues, toggleKanbanShowClosedIssues } = useAppStore();
+  const {
+    owner, repo, fetchIssues, fetchProjects, fetchMilestones, fetchAllProjectStatuses,
+    signOut, loading, view, setView, showClosedIssues, toggleShowClosedIssues,
+    kanbanShowClosedIssues, toggleKanbanShowClosedIssues,
+  } = useAppStore();
+
   const activeShowClosed = (view === 'kanban' || view === 'table') ? kanbanShowClosedIssues : showClosedIssues;
   const activeToggleClosed = (view === 'kanban' || view === 'table') ? toggleKanbanShowClosedIssues : toggleShowClosedIssues;
+
   const [showCreate, setShowCreate] = useState(false);
+  const [showChangeRepo, setShowChangeRepo] = useState(false);
 
   return (
     <>
-      <header className="bg-white border-b border-gray-200 px-6 shrink-0">
-        <div className="flex items-end justify-between">
-          {/* Pill + Tabs */}
-          <div className="flex items-end gap-1">
-            <a
-              href={`https://github.com/${owner}/${repo}/issues`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="self-center mr-2 px-2.5 py-1 text-xs font-medium bg-green-100 text-green-700 border border-green-200 rounded-full shrink-0 cursor-pointer hover:brightness-95 transition-[filter]"
+      <aside
+        className="w-56 shrink-0 flex flex-col border-r overflow-y-auto"
+        style={{
+          background: 'var(--n-sidebar)',
+          borderColor: 'var(--n-border)',
+        }}
+      >
+        {/* Workspace header */}
+        <div className="px-3 pt-4 pb-2">
+          <a
+            href={`https://github.com/${owner}/${repo}/issues`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-2 py-1.5 rounded-md transition-colors group"
+            style={{ color: 'var(--n-text)' }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--n-hover-strong)')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          >
+            <span
+              className="w-5 h-5 rounded flex items-center justify-center text-xs font-bold text-white shrink-0"
+              style={{ background: 'var(--n-blue)' }}
             >
-              {owner}/{repo}
-            </a>
-            {(['grid', 'kanban', 'table', 'roadmap', 'timeline', 'waves', 'user-activities', 'settings'] as const).map((v) => (
+              {(repo[0] ?? 'G').toUpperCase()}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-semibold truncate" style={{ color: 'var(--n-text)' }}>
+                {repo}
+              </div>
+              <div className="text-xs truncate" style={{ color: 'var(--n-text-3)' }}>
+                {owner}
+              </div>
+            </div>
+          </a>
+
+          {/* Change repo button */}
+          <button
+            onClick={() => setShowChangeRepo(true)}
+            className="mt-1 w-full text-left px-2 py-1 rounded-md text-xs transition-colors"
+            style={{ color: 'var(--n-text-3)' }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = 'var(--n-hover)';
+              e.currentTarget.style.color = 'var(--n-text-2)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = 'var(--n-text-3)';
+            }}
+          >
+            ↗ switch repo
+          </button>
+        </div>
+
+        {/* Divider */}
+        <div className="mx-3 mb-1" style={{ height: 1, background: 'var(--n-border)' }} />
+
+        {/* Quick actions */}
+        <div className="px-3 py-1 flex items-center gap-1">
+          {/* New issue */}
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex-1 flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium transition-colors"
+            style={{ color: 'var(--n-text-2)' }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = 'var(--n-hover)';
+              e.currentTarget.style.color = 'var(--n-text)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = 'var(--n-text-2)';
+            }}
+            title="New issue"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            New issue
+          </button>
+
+          {/* Sync */}
+          <button
+            onClick={() => { fetchIssues(); fetchProjects().then(() => fetchAllProjectStatuses()); fetchMilestones(); }}
+            disabled={loading}
+            className="p-1.5 rounded-md transition-colors disabled:opacity-40"
+            style={{ color: 'var(--n-text-3)' }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = 'var(--n-hover)';
+              e.currentTarget.style.color = 'var(--n-text)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = 'var(--n-text-3)';
+            }}
+            title={loading ? 'Syncing…' : 'Sync'}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`} viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Divider */}
+        <div className="mx-3 mb-1 mt-0.5" style={{ height: 1, background: 'var(--n-border)' }} />
+
+        {/* Navigation */}
+        <nav className="flex-1 px-2 py-1 space-y-0.5">
+          {NAV_ITEMS.map(({ view: v, label, icon }) => {
+            const isActive = view === v;
+            return (
               <button
                 key={v}
                 onClick={() => setView(v)}
-                className={`px-4 py-2 text-sm font-medium rounded-t transition-colors -mb-px ${
-                  view === v
-                    ? 'border border-gray-200 border-b-white text-gray-900 bg-white'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
+                className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left"
+                style={{
+                  background: isActive ? 'var(--n-hover-strong)' : 'transparent',
+                  color: isActive ? 'var(--n-text)' : 'var(--n-text-2)',
+                  fontWeight: isActive ? 500 : 400,
+                }}
+                onMouseEnter={(e) => {
+                  if (!isActive) {
+                    e.currentTarget.style.background = 'var(--n-hover)';
+                    e.currentTarget.style.color = 'var(--n-text)';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isActive) {
+                    e.currentTarget.style.background = 'transparent';
+                    e.currentTarget.style.color = 'var(--n-text-2)';
+                  }
+                }}
               >
-                {VIEW_LABELS[v]}
+                <span style={{ opacity: isActive ? 1 : 0.7 }}>{icon}</span>
+                {label}
               </button>
-            ))}
-          </div>
+            );
+          })}
+        </nav>
 
-          {/* Action buttons */}
-          <div className="self-center flex items-center gap-1">
-            {/* Show/hide closed */}
-            <div className="relative group">
-              <button
-                onClick={activeToggleClosed}
-                className="p-2 rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-colors"
-              >
-                {activeShowClosed ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
-                    <path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd" />
-                  </svg>
-                ) : (
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clipRule="evenodd" />
-                    <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.064 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
-                  </svg>
-                )}
-              </button>
-              <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity">
-                {activeShowClosed ? 'Hide closed issues' : 'Show closed issues'}
-              </span>
-            </div>
+        {/* Bottom actions */}
+        <div className="px-2 pb-3 space-y-0.5">
+          <div className="mx-1 mb-1" style={{ height: 1, background: 'var(--n-border)' }} />
 
-            {/* New Issue */}
-            <div className="relative group">
-              <button
-                onClick={() => setShowCreate(true)}
-                className="p-2 rounded-lg text-white bg-blue-600 hover:bg-blue-700 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
-                </svg>
-              </button>
-              <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity">
-                New issue
-              </span>
-            </div>
+          {/* Show/hide closed */}
+          <button
+            onClick={activeToggleClosed}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left"
+            style={{ color: 'var(--n-text-2)' }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = 'var(--n-hover)';
+              e.currentTarget.style.color = 'var(--n-text)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = 'var(--n-text-2)';
+            }}
+          >
+            {activeShowClosed ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
+                <path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clipRule="evenodd" />
+                <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.064 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
+              </svg>
+            )}
+            <span>{activeShowClosed ? 'Hide closed' : 'Show closed'}</span>
+          </button>
 
-            {/* Sync */}
-            <div className="relative group">
-              <button
-                onClick={() => { fetchIssues(); fetchProjects().then(() => fetchAllProjectStatuses()); fetchMilestones(); }}
-                disabled={loading}
-                className="p-2 rounded-lg bg-orange-500 text-white hover:bg-orange-600 disabled:opacity-40 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
-                </svg>
-              </button>
-              <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity">
-                {loading ? 'Syncing…' : 'Sync'}
-              </span>
-            </div>
-
-            {/* Sign out */}
-            <div className="relative group">
-              <button
-                onClick={() => { void signOut(); }}
-                className="p-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clipRule="evenodd" />
-                </svg>
-              </button>
-              <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity">
-                Sign out
-              </span>
-            </div>
-          </div>
+          {/* Sign out */}
+          <button
+            onClick={() => { void signOut(); }}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left"
+            style={{ color: 'var(--n-text-3)' }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = 'var(--n-hover)';
+              e.currentTarget.style.color = 'var(--n-text-2)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = 'var(--n-text-3)';
+            }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clipRule="evenodd" />
+            </svg>
+            Sign out
+          </button>
         </div>
-      </header>
+      </aside>
 
       {showCreate && <CreateIssueModal onClose={() => setShowCreate(false)} />}
+      {showChangeRepo && <ChangeRepoModal onClose={() => setShowChangeRepo(false)} />}
     </>
   );
 }

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -13,13 +13,12 @@ interface Props {
 }
 
 export default function IssueCard({ issue }: Props) {
-  const { closeIssue, deleteIssue, reopenIssue, kanbanIssueStatuses, kanbanStatusColors } = useAppStore();
+  const { kanbanIssueStatuses, kanbanStatusColors } = useAppStore();
 
   const [showReadModal, setShowReadModal] = useState(
     () => window.location.pathname === `/issue/${issue.number}`,
   );
   const [showEdit, setShowEdit] = useState(false);
-  const [busy, setBusy] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [showBadgeTip, setShowBadgeTip] = useState(false);
   const [calloutStyle, setCalloutStyle] = useState<React.CSSProperties | null>(null);
@@ -58,33 +57,6 @@ export default function IssueCard({ issue }: Props) {
     setCalloutStyle(null);
   }
 
-  async function handleClose(e: React.MouseEvent) {
-    e.stopPropagation();
-    if (!confirm(`Close issue #${issue.number}?`)) return;
-    setBusy(true);
-    try { await closeIssue(issue.number); } catch { setBusy(false); }
-  }
-
-  async function handleReopen(e: React.MouseEvent) {
-    e.stopPropagation();
-    if (!confirm(`Reopen issue #${issue.number}?`)) return;
-    setBusy(true);
-    try { await reopenIssue(issue.number); } catch { setBusy(false); }
-    setBusy(false);
-  }
-
-  async function handleDelete(e: React.MouseEvent) {
-    e.stopPropagation();
-    if (!confirm(`Permanently delete issue #${issue.number}? This cannot be undone.`)) return;
-    setBusy(true);
-    try {
-      await deleteIssue(issue.number, issue.node_id);
-    } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to delete');
-      setBusy(false);
-    }
-  }
-
   return (
     <>
       <div
@@ -93,7 +65,6 @@ export default function IssueCard({ issue }: Props) {
         onMouseLeave={onCardLeave}
         onClick={() => setShowReadModal(true)}
         className={`relative select-none cursor-pointer text-sm ${hovered ? 'z-20' : ''} ${
-          busy ? 'opacity-40 pointer-events-none' :
           issue.state === 'closed' ? 'opacity-50' : ''
         }`}
       >
@@ -162,64 +133,6 @@ export default function IssueCard({ issue }: Props) {
             )}
           </div>
 
-          {/* Hover action buttons */}
-          <div
-            className={`absolute right-1 inset-y-0 flex items-center gap-0.5 transition-opacity ${hovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-          >
-            <button
-              onClick={e => { e.stopPropagation(); setShowEdit(true); }}
-              title="Edit issue"
-              className="p-1 rounded transition-colors"
-              style={{ color: 'var(--n-text-2)' }}
-              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
-              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-              </svg>
-            </button>
-
-            {issue.state === 'open' ? (
-              <button
-                onClick={handleClose}
-                title="Close issue"
-                className="p-1 rounded transition-colors"
-                style={{ color: 'var(--n-text-2)' }}
-                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
-                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                </svg>
-              </button>
-            ) : (
-              <button
-                onClick={handleReopen}
-                title="Reopen issue"
-                className="p-1 rounded transition-colors"
-                style={{ color: 'var(--n-text-2)' }}
-                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; }}
-                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
-                </svg>
-              </button>
-            )}
-
-            <button
-              onClick={handleDelete}
-              title="Delete issue permanently"
-              className="p-1 rounded transition-colors"
-              style={{ color: 'var(--n-text-3)' }}
-              onMouseEnter={(e) => { e.currentTarget.style.background = '#FFF2F2'; e.currentTarget.style.color = '#E03E3E'; }}
-              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-3)'; }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-              </svg>
-            </button>
-          </div>
         </div>
       </div>
 

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -6,11 +6,6 @@ import EditIssueModal from './EditIssueModal';
 import IssueReadModal from './IssueReadModal';
 import { ghStyle } from '../lib/githubColors';
 
-function truncateMiddle(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max - 6) + '...' + text.slice(-3);
-}
-
 interface Props {
   issue: GitHubIssue;
   hideLabels?: boolean;
@@ -20,16 +15,10 @@ interface Props {
 export default function IssueCard({ issue }: Props) {
   const { closeIssue, deleteIssue, reopenIssue, kanbanIssueStatuses, kanbanStatusColors } = useAppStore();
 
-  // Read-only view — opens when the card body is clicked or when the URL
-  // already points to this issue (deep-link / page-refresh support).
   const [showReadModal, setShowReadModal] = useState(
     () => window.location.pathname === `/issue/${issue.number}`,
   );
-
-  // Direct-edit path — opened via the hover-action Edit button (fast path)
-  // so power-users can skip the read modal entirely.
   const [showEdit, setShowEdit] = useState(false);
-
   const [busy, setBusy] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [showBadgeTip, setShowBadgeTip] = useState(false);
@@ -37,7 +26,6 @@ export default function IssueCard({ issue }: Props) {
   const cardRef = useRef<HTMLDivElement>(null);
   const calloutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Keep the browser URL in sync with the read modal.
   useEffect(() => {
     if (showReadModal) {
       history.pushState({}, '', `/issue/${issue.number}`);
@@ -106,17 +94,20 @@ export default function IssueCard({ issue }: Props) {
         onClick={() => setShowReadModal(true)}
         className={`relative select-none cursor-pointer text-sm ${hovered ? 'z-20' : ''} ${
           busy ? 'opacity-40 pointer-events-none' :
-          issue.state === 'closed' ? 'opacity-60' : ''
+          issue.state === 'closed' ? 'opacity-50' : ''
         }`}
       >
-        <div className={`relative bg-white rounded-lg border px-2 py-1.5 shadow-sm transition-all ${
-          hovered ? 'border-gray-300 shadow-md' : 'border-gray-200'
-        }`}>
-
+        <div
+          className="relative px-2 py-1.5 rounded-md transition-all"
+          style={{
+            background: 'var(--n-bg)',
+            border: `1px solid ${hovered ? 'rgba(55,53,47,0.2)' : 'var(--n-border)'}`,
+            boxShadow: hovered ? '0 1px 4px rgba(0,0,0,0.07)' : 'none',
+          }}
+        >
           {/* Title row */}
           <div className="flex items-start gap-1.5 min-w-0">
-
-            {/* ID badge — background reflects open/closed state; tooltip on hover */}
+            {/* ID badge */}
             <div
               className="relative shrink-0"
               onMouseEnter={() => setShowBadgeTip(true)}
@@ -127,21 +118,25 @@ export default function IssueCard({ issue }: Props) {
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={e => e.stopPropagation()}
-                className="block px-1.5 py-0.5 rounded-full text-xs font-medium tabular-nums leading-none transition-colors"
+                className="block px-1.5 py-0.5 rounded text-xs font-medium tabular-nums leading-none transition-opacity hover:opacity-80"
                 style={badgeStyle}
               >
                 #{issue.number}
               </a>
 
               {showBadgeTip && (
-                <div className="absolute bottom-full left-0 mb-1.5 z-30 bg-gray-900 text-white text-xs rounded-md px-2.5 py-2 shadow-lg whitespace-nowrap min-w-max">
+                <div
+                  className="absolute bottom-full left-0 mb-1.5 z-30 text-xs rounded-md px-2.5 py-2 shadow-lg whitespace-nowrap min-w-max"
+                  style={{ background: 'var(--n-text)', color: '#fff' }}
+                >
                   {nativeStatus && <div className="font-semibold mb-1">{nativeStatus}</div>}
                   <a
                     href={issue.html_url}
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={e => e.stopPropagation()}
-                    className="text-blue-300 hover:text-blue-200 transition-colors"
+                    className="hover:underline"
+                    style={{ color: '#8BBFE8' }}
                   >
                     View on GitHub →
                   </a>
@@ -149,12 +144,15 @@ export default function IssueCard({ issue }: Props) {
               )}
             </div>
 
-            {/* Title — up to 2 lines */}
-            <span className="flex-1 min-w-0 text-gray-900 font-medium leading-snug line-clamp-2">
+            {/* Title */}
+            <span
+              className="flex-1 min-w-0 font-medium leading-snug line-clamp-2"
+              style={{ color: 'var(--n-text)', fontSize: '0.8125rem' }}
+            >
               {issue.title}
             </span>
 
-            {/* Assignees — inline so they never add height */}
+            {/* Assignees */}
             {issue.assignees.length > 0 && (
               <div className="flex shrink-0 -space-x-1">
                 {issue.assignees.map((user) => (
@@ -164,27 +162,33 @@ export default function IssueCard({ issue }: Props) {
             )}
           </div>
 
-          {/* Action buttons — absolute overlay on the right, visible on hover */}
-          <div className={`absolute right-1.5 inset-y-0 flex items-center gap-1 transition-opacity ${hovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
-            {/* Edit — fast path: bypasses the read modal and opens the edit form directly */}
+          {/* Hover action buttons */}
+          <div
+            className={`absolute right-1 inset-y-0 flex items-center gap-0.5 transition-opacity ${hovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+          >
             <button
               onClick={e => { e.stopPropagation(); setShowEdit(true); }}
               title="Edit issue"
-              className="text-blue-500 p-1 rounded-md border border-blue-200 bg-blue-50 hover:bg-blue-100 transition-colors"
+              className="p-1 rounded transition-colors"
+              style={{ color: 'var(--n-text-2)' }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
                 <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
               </svg>
             </button>
 
-            {/* Close (open issues) / Reopen (closed issues) */}
             {issue.state === 'open' ? (
               <button
                 onClick={handleClose}
                 title="Close issue"
-                className="text-green-600 p-1 rounded-md border border-green-200 bg-green-50 hover:bg-green-100 transition-colors"
+                className="p-1 rounded transition-colors"
+                style={{ color: 'var(--n-text-2)' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                 </svg>
               </button>
@@ -192,9 +196,12 @@ export default function IssueCard({ issue }: Props) {
               <button
                 onClick={handleReopen}
                 title="Reopen issue"
-                className="text-purple-600 p-1 rounded-md border border-purple-200 bg-purple-50 hover:bg-purple-100 transition-colors"
+                className="p-1 rounded transition-colors"
+                style={{ color: 'var(--n-text-2)' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
                 </svg>
               </button>
@@ -203,41 +210,48 @@ export default function IssueCard({ issue }: Props) {
             <button
               onClick={handleDelete}
               title="Delete issue permanently"
-              className="text-red-500 p-1 rounded-md border border-red-200 bg-red-50 hover:bg-red-100 transition-colors"
+              className="p-1 rounded transition-colors"
+              style={{ color: 'var(--n-text-3)' }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = '#FFF2F2'; e.currentTarget.style.color = '#E03E3E'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-3)'; }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
             </button>
           </div>
-
         </div>
       </div>
 
-      {/* Description callout — rendered into body to escape any stacking context */}
+      {/* Description callout on hover */}
       {calloutStyle && createPortal(
         <div
-          style={calloutStyle}
-          className="pointer-events-none bg-white border border-gray-200 rounded-lg shadow-xl p-3"
+          style={{
+            ...calloutStyle,
+            background: 'var(--n-bg)',
+            border: '1px solid var(--n-border)',
+            borderRadius: 8,
+            boxShadow: 'var(--n-shadow-lg)',
+            padding: '12px 14px',
+          }}
+          className="pointer-events-none"
         >
-          <div className="font-semibold text-gray-900 text-xs mb-1.5">{issue.title}</div>
+          <div className="font-semibold text-xs mb-1.5" style={{ color: 'var(--n-text)' }}>{issue.title}</div>
           {issue.body ? (
-            <div className="text-gray-500 text-xs leading-relaxed line-clamp-6 whitespace-pre-wrap break-words">
+            <div className="text-xs leading-relaxed line-clamp-6 whitespace-pre-wrap break-words" style={{ color: 'var(--n-text-2)' }}>
               {issue.body}
             </div>
           ) : (
-            <div className="text-gray-400 text-xs italic">No description.</div>
+            <div className="text-xs italic" style={{ color: 'var(--n-text-3)' }}>No description.</div>
           )}
         </div>,
         document.body
       )}
 
-      {/* Read-only view — opened by clicking the card body */}
       {showReadModal && (
         <IssueReadModal issue={issue} onClose={() => setShowReadModal(false)} />
       )}
 
-      {/* Direct-edit fast path — opened via the hover Edit button */}
       {showEdit && (
         <EditIssueModal issue={issue} onClose={() => setShowEdit(false)} />
       )}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -18,34 +18,61 @@ export default function Login() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-200 w-full max-w-md p-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-1">GitHub Story Map</h1>
-        <p className="text-gray-500 text-sm mb-6">
-          Sign in with your GitHub account to manage your story map.
+    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: 'var(--n-sidebar)' }}>
+      <div
+        className="w-full max-w-sm p-8 rounded-xl"
+        style={{ background: 'var(--n-bg)', border: '1px solid var(--n-border)', boxShadow: 'var(--n-shadow-lg)' }}
+      >
+        {/* Logo mark */}
+        <div className="mb-6 flex items-center gap-3">
+          <div
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-white font-bold text-sm"
+            style={{ background: 'var(--n-blue)' }}
+          >
+            G
+          </div>
+          <div>
+            <h1 className="text-base font-semibold" style={{ color: 'var(--n-text)' }}>
+              GitHub Story Map
+            </h1>
+            <p className="text-xs" style={{ color: 'var(--n-text-3)' }}>
+              Issue planning, your way
+            </p>
+          </div>
+        </div>
+
+        <p className="text-sm mb-6" style={{ color: 'var(--n-text-2)' }}>
+          Sign in with GitHub to get started.
         </p>
 
         <button
           type="button"
           onClick={handleClick}
           disabled={busy}
-          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          className="w-full flex items-center justify-center gap-2.5 px-4 py-2.5 rounded-md text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{ background: 'var(--n-text)', color: '#fff' }}
+          onMouseEnter={(e) => { if (!busy) e.currentTarget.style.opacity = '0.88'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
         >
-          <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <svg className="w-4 h-4 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38v-1.34c-2.23.49-2.7-1.07-2.7-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82a7.65 7.65 0 014 0c1.54-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.74-3.65 3.94.29.25.54.74.54 1.49v2.21c0 .21.15.46.55.38A8 8 0 0016 8c0-4.42-3.58-8-8-8z" />
           </svg>
-          {busy ? 'Signing in…' : 'Sign in with GitHub'}
+          {busy ? 'Signing in…' : 'Continue with GitHub'}
         </button>
 
         {authError && (
-          <div className="mt-4 bg-red-50 border border-red-200 rounded-lg px-3 py-2 text-sm text-red-700">
+          <div
+            className="mt-4 px-3 py-2.5 rounded-md text-xs"
+            style={{ background: '#FFF2F2', border: '1px solid #FFD5D5', color: '#E03E3E' }}
+          >
             {authError}
           </div>
         )}
 
-        <p className="text-xs text-gray-400 mt-6">
-          We request the <code>repo</code> and <code>project</code> scopes so the app can read & write
-          issues, milestones, labels, and Projects v2 fields on your behalf.
+        <p className="text-xs mt-6" style={{ color: 'var(--n-text-3)' }}>
+          Requests <code style={{ fontFamily: 'monospace' }}>repo</code> and{' '}
+          <code style={{ fontFamily: 'monospace' }}>project</code> scopes to read and write
+          issues, milestones, labels, and Projects v2 fields.
         </p>
       </div>
     </div>

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -329,41 +329,44 @@ export default function StoryMap() {
                 type="COLUMN"
                 renderClone={(provided, _snapshot, rubric) => {
                   const project = cols[rubric.source.index];
-                  if (!project) return <th ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} />;
+                  if (!project) return <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} />;
                   const w = colW(project.id);
+                  // The library sets height = measured header height in draggableProps.style,
+                  // which clips the clone to header-only. Strip it so the full column shows.
+                  const { height: _h, ...dndStyle } = (provided.draggableProps.style ?? {}) as React.CSSProperties;
                   return (
-                    <th
+                    <div
                       ref={provided.innerRef}
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       style={{
-                        ...provided.draggableProps.style,
+                        ...dndStyle,
                         width: w,
                         minWidth: w,
-                        padding: 0,
-                        verticalAlign: 'top',
+                        maxHeight: '80vh',
+                        overflowY: 'auto',
                         borderRadius: 6,
-                        overflow: 'hidden',
-                        boxShadow: '0 8px 32px rgba(0,0,0,0.16)',
+                        boxShadow: '0 8px 32px rgba(0,0,0,0.18)',
                         border: '1px solid var(--n-border)',
+                        background: 'var(--n-bg)',
                       }}
                     >
                       {/* Header */}
-                      <div style={{ padding: '10px 16px', background: 'var(--n-sidebar)', borderBottom: '1px solid var(--n-border)', fontWeight: 500, fontSize: '0.875rem', color: 'var(--n-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      <div style={{ padding: '10px 16px', background: 'var(--n-sidebar)', borderBottom: '1px solid var(--n-border)', fontWeight: 500, fontSize: '0.875rem', color: 'var(--n-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', position: 'sticky', top: 0, zIndex: 1 }}>
                         {project.title}
                       </div>
-                      {/* Row cells preview */}
-                      {[...orderedMilestones.map(m => ({ label: m.title, items: cellIssues(project.id, m.number) })), { label: null, items: cellIssues(project.id, null) }].map(({ label, items }, i) => (
-                        <div key={i} style={{ padding: '6px 8px', minHeight: 48, background: 'var(--n-bg)', borderBottom: '1px solid var(--n-border)' }}>
+                      {/* Row cells */}
+                      {[...orderedMilestones.map(m => ({ label: m.title, items: cellIssues(project.id, m.number) })), { label: null, items: cellIssues(project.id, null) }].map(({ items }, i) => (
+                        <div key={i} style={{ padding: '6px 8px', minHeight: 48, borderBottom: '1px solid var(--n-border)' }}>
                           {items.slice(0, 4).map(issue => (
-                            <div key={issue.number} style={{ padding: '3px 6px', marginBottom: 3, borderRadius: 4, border: '1px solid var(--n-border)', fontSize: '0.75rem', color: 'var(--n-text)', background: 'var(--n-bg)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            <div key={issue.number} style={{ padding: '3px 6px', marginBottom: 3, borderRadius: 4, border: '1px solid var(--n-border)', fontSize: '0.75rem', color: 'var(--n-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                               {issue.title}
                             </div>
                           ))}
                           {items.length > 4 && <div style={{ fontSize: '0.7rem', color: 'var(--n-text-3)', paddingLeft: 4 }}>+{items.length - 4} more</div>}
                         </div>
                       ))}
-                    </th>
+                    </div>
                   );
                 }}
               >

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -76,7 +76,11 @@ function CardCell({ droppableId, items, onAdd }: CardCellProps) {
                   ref={provided.innerRef}
                   {...provided.draggableProps}
                   {...provided.dragHandleProps}
-                  className={`transition-opacity ${snapshot.isDragging ? 'opacity-70 rotate-1' : ''}`}
+                  style={{
+                    ...provided.draggableProps.style,
+                    boxShadow: snapshot.isDragging ? 'var(--n-shadow-lg)' : undefined,
+                    borderRadius: snapshot.isDragging ? 6 : undefined,
+                  }}
                 >
                   <IssueCard issue={issue} hideLabels showStatus />
                 </div>
@@ -314,8 +318,10 @@ export default function StoryMap() {
                             columnKey={project.id}
                             width={colW(project.id)}
                             onResize={setColumnWidth}
-                            className="sticky top-0 z-20 px-4 py-3 text-sm font-medium text-center whitespace-nowrap cursor-grab select-none transition-colors"
+                            className="sticky top-0 z-20 px-4 py-3 text-sm font-medium text-center whitespace-nowrap cursor-grab select-none"
                             style={{
+                              // DnD transform/position MUST come first so our visual styles layer on top
+                              ...provided.draggableProps.style,
                               background: snapshot.isDragging ? 'var(--n-hover-strong)' : 'var(--n-sidebar)',
                               color: 'var(--n-text)',
                               borderRight: '1px solid var(--n-border)',
@@ -382,12 +388,17 @@ export default function StoryMap() {
                         <tr
                           ref={provided.innerRef}
                           {...provided.draggableProps}
-                          style={provided.draggableProps.style}
+                          style={{
+                            ...provided.draggableProps.style,
+                            // When lifted out of the table, cells lose their widths.
+                            // Force the row to display as a flex row so explicit cell widths hold.
+                            ...(snapshot.isDragging ? { display: 'flex', opacity: 0.92 } : {}),
+                          }}
                         >
                           {/* Row label — sticky left, not resizable */}
                           <th
                             {...provided.dragHandleProps}
-                            className="sticky left-0 z-10 px-3 py-2 text-xs font-medium text-right align-top pt-3 cursor-grab select-none transition-colors w-[200px] min-w-[200px] max-w-[200px]"
+                            className="px-3 py-2 text-xs font-medium text-right align-top pt-3 cursor-grab select-none w-[200px] min-w-[200px] max-w-[200px] shrink-0"
                             style={{
                               background: snapshot.isDragging ? 'var(--n-hover-strong)' : 'var(--n-sidebar)',
                               color: 'var(--n-text-2)',
@@ -403,7 +414,7 @@ export default function StoryMap() {
                           {cols.map((project) => (
                             <td
                               key={project.id}
-                              className="align-top p-2"
+                              className="align-top p-2 shrink-0"
                               style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id) }}
                             >
                               <CardCell
@@ -416,7 +427,7 @@ export default function StoryMap() {
 
                           {/* No User Activity cell */}
                           <td
-                            className="align-top p-2"
+                            className="align-top p-2 shrink-0"
                             style={{ background: 'var(--n-sidebar)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW('__no_user_activity__'), minWidth: colW('__no_user_activity__') }}
                           >
                             <CardCell

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -169,7 +169,7 @@ export default function StoryMap() {
   const orderedMilestones = sortedMilestones(milestones, layout.milestoneOrder).filter(
     (m) => showClosedIssues || visibleIssues.some((i) => i.milestone?.number === m.number),
   );
-  const showNoWaveRow = showClosedIssues || visibleIssues.some((i) => i.milestone === null);
+  const showNoWaveRow = true;
 
   function cellIssues(projectId: string, milestoneNumber: number | null): GitHubIssue[] {
     const inProject = new Set(projectIssues[projectId] ?? []);

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -59,19 +59,15 @@ interface CardCellProps {
   addColor?: 'blue' | 'gray';
 }
 
-function CardCell({ droppableId, items, onAdd, addColor = 'blue' }: CardCellProps) {
-  const hoverCls = addColor === 'gray'
-    ? 'hover:text-gray-600 hover:bg-gray-100 hover:border-gray-300'
-    : 'hover:text-blue-500 hover:bg-blue-50 hover:border-blue-300';
+function CardCell({ droppableId, items, onAdd }: CardCellProps) {
   return (
     <Droppable droppableId={droppableId} type="CARD">
       {(provided, snapshot) => (
         <div
           ref={provided.innerRef}
           {...provided.droppableProps}
-          className={`flex flex-col gap-2 min-h-16 rounded transition-colors ${
-            snapshot.isDraggingOver ? 'bg-blue-50/60' : ''
-          }`}
+          className="flex flex-col gap-1.5 min-h-16 rounded-md transition-colors"
+          style={{ background: snapshot.isDraggingOver ? 'rgba(35,131,226,0.05)' : 'transparent' }}
         >
           {items.map((issue, idx) => (
             <Draggable key={issue.number} draggableId={`i:${issue.number}`} index={idx}>
@@ -80,7 +76,7 @@ function CardCell({ droppableId, items, onAdd, addColor = 'blue' }: CardCellProp
                   ref={provided.innerRef}
                   {...provided.draggableProps}
                   {...provided.dragHandleProps}
-                  className={`transition-opacity ${snapshot.isDragging ? 'opacity-75 rotate-1 shadow-lg' : ''}`}
+                  className={`transition-opacity ${snapshot.isDragging ? 'opacity-70 rotate-1' : ''}`}
                 >
                   <IssueCard issue={issue} hideLabels showStatus />
                 </div>
@@ -90,7 +86,10 @@ function CardCell({ droppableId, items, onAdd, addColor = 'blue' }: CardCellProp
           {provided.placeholder}
           <button
             onClick={onAdd}
-            className={`mt-auto w-full text-xs text-gray-400 ${hoverCls} rounded-lg py-1.5 border border-dashed border-gray-200 transition-colors flex items-center justify-center gap-1`}
+            className="mt-auto w-full text-xs py-1.5 rounded-md transition-colors flex items-center justify-center gap-1"
+            style={{ color: 'var(--n-text-3)', border: '1px dashed var(--n-border)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--n-text-2)'; e.currentTarget.style.background = 'var(--n-hover)'; e.currentTarget.style.borderColor = 'rgba(55,53,47,0.2)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--n-text-3)'; e.currentTarget.style.background = 'transparent'; e.currentTarget.style.borderColor = 'var(--n-border)'; }}
           >
             <span className="text-sm font-medium leading-none">+</span>
             New Issue
@@ -215,44 +214,55 @@ export default function StoryMap() {
 
   if (cols.length === 0) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center bg-gray-50 p-8">
+      <div className="flex-1 flex flex-col items-center justify-center p-8" style={{ background: 'var(--n-bg)' }}>
         <div className="flex flex-col items-center max-w-sm text-center">
-          <div className="w-16 h-16 rounded-2xl bg-blue-50 flex items-center justify-center text-blue-500 mb-4 animate-bounce">
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          <div
+            className="w-14 h-14 rounded-xl flex items-center justify-center mb-4"
+            style={{ background: 'var(--n-hover-strong)' }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor" style={{ color: 'var(--n-text-2)' }}>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
             </svg>
           </div>
-          <h3 className="text-lg font-semibold text-gray-900 mb-1.5">No active User Activities</h3>
-          <p className="text-gray-500 text-sm mb-6">
+          <h3 className="text-base font-semibold mb-1.5" style={{ color: 'var(--n-text)' }}>No active User Activities</h3>
+          <p className="text-sm mb-6" style={{ color: 'var(--n-text-2)' }}>
             Cherry-pick which User Activities (GitHub Projects) are included in this repo's Story Map, or create a brand new one to get started.
           </p>
           <div className="flex flex-col gap-2 w-full">
             <button
               onClick={() => setView('user-activities')}
-              className="w-full px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
+              className="w-full px-4 py-2 text-sm font-medium rounded-md transition-colors"
+              style={{ background: 'var(--n-blue)', color: '#fff' }}
+              onMouseEnter={(e) => { e.currentTarget.style.opacity = '0.88'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
             >
               Cherry-Pick User Activities
             </button>
             {addingUserActivity ? (
-              <form onSubmit={handleCreateUserActivity} className="flex items-center gap-2 mt-2 w-full">
+              <form onSubmit={handleCreateUserActivity} className="flex items-center gap-2 mt-1 w-full">
                 <input
                   autoFocus
                   value={newUserActivityTitle}
                   onChange={(e) => setNewUserActivityTitle(e.target.value)}
                   placeholder="User activity name…"
-                  className="flex-1 min-w-0 border border-blue-300 rounded-lg px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
+                  className="flex-1 min-w-0 px-3 py-1.5 text-xs rounded-md outline-none"
+                  style={{ border: '1px solid var(--n-border)', background: 'var(--n-sidebar)', color: 'var(--n-text)' }}
                 />
                 <button
                   type="submit"
                   disabled={userActivitySaving || !newUserActivityTitle.trim()}
-                  className="px-3 py-1.5 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-40 transition-colors shrink-0"
+                  className="px-3 py-1.5 text-xs font-medium rounded-md disabled:opacity-40 transition-colors shrink-0"
+                  style={{ background: 'var(--n-blue)', color: '#fff' }}
                 >
                   {userActivitySaving ? '…' : 'Create'}
                 </button>
                 <button
                   type="button"
                   onClick={() => { setAddingUserActivity(false); setNewUserActivityTitle(''); }}
-                  className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors shrink-0"
+                  className="px-3 py-1.5 text-xs rounded-md transition-colors shrink-0"
+                  style={{ color: 'var(--n-text-2)' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
                 >
                   Cancel
                 </button>
@@ -260,14 +270,17 @@ export default function StoryMap() {
             ) : (
               <button
                 onClick={() => setAddingUserActivity(true)}
-                className="w-full px-4 py-2 text-sm font-medium bg-white text-gray-700 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                className="w-full px-4 py-2 text-sm font-medium rounded-md transition-colors"
+                style={{ border: '1px solid var(--n-border)', color: 'var(--n-text-2)', background: 'transparent' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover)'; e.currentTarget.style.color = 'var(--n-text)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
               >
                 + Create New Activity
               </button>
             )}
           </div>
           {moveError && (
-            <p className="text-red-500 text-xs mt-4">{moveError}</p>
+            <p className="text-xs mt-4" style={{ color: '#E03E3E' }}>{moveError}</p>
           )}
         </div>
       </div>
@@ -285,7 +298,10 @@ export default function StoryMap() {
                 {(provided) => (
                   <tr ref={provided.innerRef} {...provided.droppableProps}>
                     {/* Sticky corner — row-label placeholder, not resizable */}
-                    <th className="sticky left-0 top-0 z-30 bg-white border border-gray-200 w-[200px] min-w-[200px] max-w-[200px]" />
+                    <th
+                      className="sticky left-0 top-0 z-30 w-[200px] min-w-[200px] max-w-[200px]"
+                      style={{ background: 'var(--n-sidebar)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)' }}
+                    />
 
                     {/* Draggable + resizable user activity column headers */}
                     {cols.map((project, index) => (
@@ -298,11 +314,16 @@ export default function StoryMap() {
                             columnKey={project.id}
                             width={colW(project.id)}
                             onResize={setColumnWidth}
-                            className={`sticky top-0 z-20 border border-gray-200 px-4 py-3 text-sm font-semibold text-blue-900 text-center whitespace-nowrap cursor-grab select-none transition-colors ${
-                              snapshot.isDragging ? 'bg-blue-100 shadow-lg z-50' : 'bg-blue-50'
-                            }`}
+                            className="sticky top-0 z-20 px-4 py-3 text-sm font-medium text-center whitespace-nowrap cursor-grab select-none transition-colors"
+                            style={{
+                              background: snapshot.isDragging ? 'var(--n-hover-strong)' : 'var(--n-sidebar)',
+                              color: 'var(--n-text)',
+                              borderRight: '1px solid var(--n-border)',
+                              borderBottom: '1px solid var(--n-border)',
+                              boxShadow: snapshot.isDragging ? 'var(--n-shadow)' : 'none',
+                            }}
                           >
-                            <span className="text-blue-300 mr-1.5 text-xs">&#x2803;</span>
+                            <span className="mr-1.5 text-xs" style={{ color: 'var(--n-text-3)' }}>&#x2803;</span>
                             {project.title}
                           </ResizableHeader>
                         )}
@@ -315,7 +336,8 @@ export default function StoryMap() {
                       columnKey="__no_user_activity__"
                       width={colW('__no_user_activity__')}
                       onResize={setColumnWidth}
-                      className="sticky top-0 z-20 bg-gray-50 border border-gray-200 px-2 py-2 text-sm font-semibold text-gray-500 text-center"
+                      className="sticky top-0 z-20 px-2 py-2 text-sm font-medium text-center"
+                      style={{ background: 'var(--n-sidebar)', color: 'var(--n-text-3)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)' }}
                     >
                       {addingUserActivity ? (
                         <form onSubmit={handleCreateUserActivity} className="flex items-center gap-1">
@@ -324,17 +346,21 @@ export default function StoryMap() {
                             value={newUserActivityTitle}
                             onChange={(e) => setNewUserActivityTitle(e.target.value)}
                             placeholder="User activity name\u2026"
-                            className="flex-1 min-w-0 border border-blue-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400"
+                            className="flex-1 min-w-0 px-2 py-1 text-xs rounded outline-none"
+                            style={{ border: '1px solid var(--n-blue)', background: 'var(--n-bg)', color: 'var(--n-text)' }}
                           />
-                          <button type="submit" disabled={userActivitySaving || !newUserActivityTitle.trim()} className="text-blue-600 hover:text-blue-800 disabled:opacity-40 px-1 text-base leading-none">&#x2713;</button>
-                          <button type="button" onClick={() => { setAddingUserActivity(false); setNewUserActivityTitle(''); }} className="text-gray-400 hover:text-gray-600 px-1 text-base leading-none">&#x2715;</button>
+                          <button type="submit" disabled={userActivitySaving || !newUserActivityTitle.trim()} className="disabled:opacity-40 px-1 text-base leading-none" style={{ color: 'var(--n-blue)' }}>&#x2713;</button>
+                          <button type="button" onClick={() => { setAddingUserActivity(false); setNewUserActivityTitle(''); }} className="px-1 text-base leading-none" style={{ color: 'var(--n-text-3)' }}>&#x2715;</button>
                         </form>
                       ) : (
                         <div className="flex items-center justify-between px-2">
-                          <span className="text-gray-500">No User Activity</span>
+                          <span style={{ color: 'var(--n-text-3)' }}>No User Activity</span>
                           <button
                             onClick={() => setAddingUserActivity(true)}
-                            className="text-xs text-blue-400 hover:text-blue-600 hover:bg-blue-100 rounded px-1.5 py-0.5 transition-colors"
+                            className="text-xs px-1.5 py-0.5 rounded transition-colors"
+                            style={{ color: 'var(--n-text-2)' }}
+                            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
+                            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
                           >
                             + New User Activity
                           </button>
@@ -361,11 +387,15 @@ export default function StoryMap() {
                           {/* Row label — sticky left, not resizable */}
                           <th
                             {...provided.dragHandleProps}
-                            className={`sticky left-0 z-10 border border-gray-200 px-3 py-2 text-xs font-semibold text-purple-900 text-right align-top pt-3 cursor-grab select-none transition-colors w-[200px] min-w-[200px] max-w-[200px] ${
-                              snapshot.isDragging ? 'bg-purple-100' : 'bg-purple-50'
-                            }`}
+                            className="sticky left-0 z-10 px-3 py-2 text-xs font-medium text-right align-top pt-3 cursor-grab select-none transition-colors w-[200px] min-w-[200px] max-w-[200px]"
+                            style={{
+                              background: snapshot.isDragging ? 'var(--n-hover-strong)' : 'var(--n-sidebar)',
+                              color: 'var(--n-text-2)',
+                              borderRight: '1px solid var(--n-border)',
+                              borderBottom: '1px solid var(--n-border)',
+                            }}
                           >
-                            <span className="text-purple-300 mr-1 text-xs">&#x2803;</span>
+                            <span className="mr-1 text-xs" style={{ color: 'var(--n-text-3)' }}>&#x2803;</span>
                             <span className="truncate block">{milestone.title}</span>
                           </th>
 
@@ -373,8 +403,8 @@ export default function StoryMap() {
                           {cols.map((project) => (
                             <td
                               key={project.id}
-                              className="border border-gray-200 align-top p-2 bg-white"
-                              style={{ width: colW(project.id), minWidth: colW(project.id) }}
+                              className="align-top p-2"
+                              style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id) }}
                             >
                               <CardCell
                                 droppableId={cellId(project.id, milestone.number)}
@@ -386,14 +416,13 @@ export default function StoryMap() {
 
                           {/* No User Activity cell */}
                           <td
-                            className="border border-gray-200 align-top p-2 bg-gray-50/50"
-                            style={{ width: colW('__no_user_activity__'), minWidth: colW('__no_user_activity__') }}
+                            className="align-top p-2"
+                            style={{ background: 'var(--n-sidebar)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW('__no_user_activity__'), minWidth: colW('__no_user_activity__') }}
                           >
                             <CardCell
                               droppableId={cellId('', milestone.number)}
                               items={noProjectCellIssues(milestone.number)}
                               onAdd={() => setCreateCell({ projectId: '', milestoneNumber: milestone.number })}
-                              addColor="gray"
                             />
                           </td>
                         </tr>
@@ -405,12 +434,18 @@ export default function StoryMap() {
                   {/* "No Wave" row — always last, not draggable */}
                   {showNoWaveRow && (
                   <tr key="no-wave">
-                    <th className="sticky left-0 z-10 bg-gray-50 border border-gray-200 px-2 py-2 text-xs font-semibold text-gray-500 text-right align-top pt-3 w-[200px] min-w-[200px] max-w-[200px]">
+                    <th
+                      className="sticky left-0 z-10 px-2 py-2 text-xs font-medium text-right align-top pt-3 w-[200px] min-w-[200px] max-w-[200px]"
+                      style={{ background: 'var(--n-sidebar)', color: 'var(--n-text-3)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)' }}
+                    >
                       <div className="flex items-center justify-end gap-2">
-                        <span className="text-gray-400 font-normal italic">No Wave</span>
+                        <span className="italic" style={{ color: 'var(--n-text-3)' }}>No Wave</span>
                         <button
                           onClick={() => setAddingWave(true)}
-                          className="text-xs text-purple-400 hover:text-purple-600 hover:bg-purple-100 rounded px-1.5 py-0.5 transition-colors not-italic font-semibold"
+                          className="text-xs not-italic font-medium px-1.5 py-0.5 rounded transition-colors"
+                          style={{ color: 'var(--n-text-2)' }}
+                          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
                         >
                           + New Wave
                         </button>
@@ -421,8 +456,8 @@ export default function StoryMap() {
                     {cols.map((project) => (
                       <td
                         key={project.id}
-                        className="border border-gray-200 align-top p-2 bg-white"
-                        style={{ width: colW(project.id), minWidth: colW(project.id) }}
+                        className="align-top p-2"
+                        style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id) }}
                       >
                         <CardCell
                           droppableId={cellId(project.id, null)}
@@ -434,14 +469,13 @@ export default function StoryMap() {
 
                     {/* No User Activity / No Wave corner */}
                     <td
-                      className="border border-gray-200 align-top p-2 bg-gray-50/50"
-                      style={{ width: colW('__no_user_activity__'), minWidth: colW('__no_user_activity__') }}
+                      className="align-top p-2"
+                      style={{ background: 'var(--n-sidebar)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW('__no_user_activity__'), minWidth: colW('__no_user_activity__') }}
                     >
                       <CardCell
                         droppableId={cellId('', null)}
                         items={noProjectCellIssues(null)}
                         onAdd={() => setCreateCell({ projectId: '', milestoneNumber: null })}
-                        addColor="gray"
                       />
                     </td>
                   </tr>
@@ -469,7 +503,10 @@ export default function StoryMap() {
       )}
 
       {moveError && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-red-600 text-white text-sm px-4 py-2.5 rounded-lg shadow-lg z-50">
+        <div
+          className="fixed bottom-4 left-1/2 -translate-x-1/2 text-sm px-4 py-2.5 rounded-lg z-50"
+          style={{ background: '#E03E3E', color: '#fff', boxShadow: 'var(--n-shadow-lg)' }}
+        >
           {moveError}
         </div>
       )}

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -5,7 +5,7 @@ import type { GitHubIssue, GitHubMilestone, GitHubProject } from '../types';
 import IssueCard from './IssueCard';
 import CreateIssueModal from './CreateIssueModal';
 import ResizableHeader, { GRID_DEFAULT_WIDTH } from './ResizableHeader';
-import CreateWaveDialog from './CreateWaveDialog';
+
 
 function sortedProjects(projects: GitHubProject[], userActivityOrder: number[]): GitHubProject[] {
   const open = projects.filter((p) => !p.closed);
@@ -120,6 +120,8 @@ export default function StoryMap() {
   const [userActivitySaving, setUserActivitySaving] = useState(false);
 
   const [addingWave, setAddingWave] = useState(false);
+  const [newWaveTitle, setNewWaveTitle] = useState('');
+  const [waveSaving, setWaveSaving] = useState(false);
 
   /** Returns the stored (or default) width for a given column key. */
   const colW = (key: string) => columnWidths[key] ?? GRID_DEFAULT_WIDTH;
@@ -141,6 +143,21 @@ export default function StoryMap() {
       showError(err instanceof Error ? err.message : 'Failed to create user activity');
     } finally {
       setUserActivitySaving(false);
+    }
+  }
+
+  async function handleCreateWave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newWaveTitle.trim()) return;
+    setWaveSaving(true);
+    try {
+      await createMilestone(newWaveTitle.trim(), '');
+      setNewWaveTitle('');
+      setAddingWave(false);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to create wave');
+    } finally {
+      setWaveSaving(false);
     }
   }
 
@@ -446,21 +463,36 @@ export default function StoryMap() {
                   {showNoWaveRow && (
                   <tr key="no-wave">
                     <th
-                      className="sticky left-0 z-10 px-2 py-2 text-xs font-medium text-right align-top pt-3 w-[200px] min-w-[200px] max-w-[200px]"
+                      className="sticky left-0 z-10 px-2 py-2 text-xs font-medium align-top pt-2 w-[200px] min-w-[200px] max-w-[200px]"
                       style={{ background: 'var(--n-sidebar)', color: 'var(--n-text-3)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)' }}
                     >
-                      <div className="flex items-center justify-end gap-2">
-                        <span className="italic" style={{ color: 'var(--n-text-3)' }}>No Wave</span>
-                        <button
-                          onClick={() => setAddingWave(true)}
-                          className="text-xs not-italic font-medium px-1.5 py-0.5 rounded transition-colors"
-                          style={{ color: 'var(--n-text-2)' }}
-                          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
-                          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
-                        >
-                          + New Wave
-                        </button>
-                      </div>
+                      {addingWave ? (
+                        <form onSubmit={handleCreateWave} className="flex items-center gap-1">
+                          <input
+                            autoFocus
+                            value={newWaveTitle}
+                            onChange={(e) => setNewWaveTitle(e.target.value)}
+                            placeholder="Wave name…"
+                            className="flex-1 min-w-0 px-2 py-1 text-xs rounded outline-none"
+                            style={{ border: '1px solid var(--n-blue)', background: 'var(--n-bg)', color: 'var(--n-text)' }}
+                          />
+                          <button type="submit" disabled={waveSaving || !newWaveTitle.trim()} className="disabled:opacity-40 px-1 text-base leading-none" style={{ color: 'var(--n-blue)' }}>&#x2713;</button>
+                          <button type="button" onClick={() => { setAddingWave(false); setNewWaveTitle(''); }} className="px-1 text-base leading-none" style={{ color: 'var(--n-text-3)' }}>&#x2715;</button>
+                        </form>
+                      ) : (
+                        <div className="flex items-center justify-between px-1">
+                          <span className="italic" style={{ color: 'var(--n-text-3)' }}>No Wave</span>
+                          <button
+                            onClick={() => setAddingWave(true)}
+                            className="text-xs not-italic px-1.5 py-0.5 rounded transition-colors"
+                            style={{ color: 'var(--n-text-2)' }}
+                            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--n-hover-strong)'; e.currentTarget.style.color = 'var(--n-text)'; }}
+                            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--n-text-2)'; }}
+                          >
+                            + New Wave
+                          </button>
+                        </div>
+                      )}
                     </th>
 
                     {/* User activity column cells — width follows header */}
@@ -497,13 +529,6 @@ export default function StoryMap() {
           </table>
         </div>
       </DragDropContext>
-
-      {addingWave && (
-        <CreateWaveDialog
-          onCreate={(title, description) => createMilestone(title, description)}
-          onClose={() => setAddingWave(false)}
-        />
-      )}
 
       {createCell && (
         <CreateIssueModal

--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { DragDropContext, Droppable, Draggable, type DropResult } from '@hello-pangea/dnd';
+import { DragDropContext, Droppable, Draggable, type DropResult, type DragStart } from '@hello-pangea/dnd';
 import { useAppStore } from '../store/appStore';
 import type { GitHubIssue, GitHubMilestone, GitHubProject } from '../types';
 import IssueCard from './IssueCard';
@@ -122,6 +122,7 @@ export default function StoryMap() {
   const [addingWave, setAddingWave] = useState(false);
   const [newWaveTitle, setNewWaveTitle] = useState('');
   const [waveSaving, setWaveSaving] = useState(false);
+  const [draggingColumnId, setDraggingColumnId] = useState<string | null>(null);
 
   /** Returns the stored (or default) width for a given column key. */
   const colW = (key: string) => columnWidths[key] ?? GRID_DEFAULT_WIDTH;
@@ -192,7 +193,14 @@ export default function StoryMap() {
     });
   }
 
+  function handleOnDragStart(start: DragStart) {
+    if (start.source.droppableId === 'columns') {
+      setDraggingColumnId(cols[start.source.index]?.id ?? null);
+    }
+  }
+
   function handleDragEnd(result: DropResult) {
+    setDraggingColumnId(null);
     if (!result.destination) return;
     const { draggableId, source, destination } = result;
 
@@ -310,12 +318,55 @@ export default function StoryMap() {
 
   return (
     <>
-      <DragDropContext onDragEnd={handleDragEnd}>
+      <DragDropContext onDragStart={handleOnDragStart} onDragEnd={handleDragEnd}>
         <div className="flex-1 overflow-auto h-full">
           <table className="border-collapse">
             {/* Column headers — draggable horizontally */}
             <thead>
-              <Droppable droppableId="columns" direction="horizontal" type="COLUMN">
+              <Droppable
+                droppableId="columns"
+                direction="horizontal"
+                type="COLUMN"
+                renderClone={(provided, _snapshot, rubric) => {
+                  const project = cols[rubric.source.index];
+                  if (!project) return <th ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} />;
+                  const w = colW(project.id);
+                  return (
+                    <th
+                      ref={provided.innerRef}
+                      {...provided.draggableProps}
+                      {...provided.dragHandleProps}
+                      style={{
+                        ...provided.draggableProps.style,
+                        width: w,
+                        minWidth: w,
+                        padding: 0,
+                        verticalAlign: 'top',
+                        borderRadius: 6,
+                        overflow: 'hidden',
+                        boxShadow: '0 8px 32px rgba(0,0,0,0.16)',
+                        border: '1px solid var(--n-border)',
+                      }}
+                    >
+                      {/* Header */}
+                      <div style={{ padding: '10px 16px', background: 'var(--n-sidebar)', borderBottom: '1px solid var(--n-border)', fontWeight: 500, fontSize: '0.875rem', color: 'var(--n-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                        {project.title}
+                      </div>
+                      {/* Row cells preview */}
+                      {[...orderedMilestones.map(m => ({ label: m.title, items: cellIssues(project.id, m.number) })), { label: null, items: cellIssues(project.id, null) }].map(({ label, items }, i) => (
+                        <div key={i} style={{ padding: '6px 8px', minHeight: 48, background: 'var(--n-bg)', borderBottom: '1px solid var(--n-border)' }}>
+                          {items.slice(0, 4).map(issue => (
+                            <div key={issue.number} style={{ padding: '3px 6px', marginBottom: 3, borderRadius: 4, border: '1px solid var(--n-border)', fontSize: '0.75rem', color: 'var(--n-text)', background: 'var(--n-bg)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                              {issue.title}
+                            </div>
+                          ))}
+                          {items.length > 4 && <div style={{ fontSize: '0.7rem', color: 'var(--n-text-3)', paddingLeft: 4 }}>+{items.length - 4} more</div>}
+                        </div>
+                      ))}
+                    </th>
+                  );
+                }}
+              >
                 {(provided) => (
                   <tr ref={provided.innerRef} {...provided.droppableProps}>
                     {/* Sticky corner — row-label placeholder, not resizable */}
@@ -337,13 +388,13 @@ export default function StoryMap() {
                             onResize={setColumnWidth}
                             className="sticky top-0 z-20 px-4 py-3 text-sm font-medium text-center whitespace-nowrap cursor-grab select-none"
                             style={{
-                              // DnD transform/position MUST come first so our visual styles layer on top
                               ...provided.draggableProps.style,
-                              background: snapshot.isDragging ? 'var(--n-hover-strong)' : 'var(--n-sidebar)',
+                              // renderClone handles the drag visual; hide the original in place
+                              visibility: snapshot.isDragging ? 'hidden' : undefined,
+                              background: 'var(--n-sidebar)',
                               color: 'var(--n-text)',
                               borderRight: '1px solid var(--n-border)',
                               borderBottom: '1px solid var(--n-border)',
-                              boxShadow: snapshot.isDragging ? 'var(--n-shadow)' : 'none',
                             }}
                           >
                             <span className="mr-1.5 text-xs" style={{ color: 'var(--n-text-3)' }}>&#x2803;</span>
@@ -432,7 +483,7 @@ export default function StoryMap() {
                             <td
                               key={project.id}
                               className="align-top p-2 shrink-0"
-                              style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id) }}
+                              style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id), visibility: draggingColumnId === project.id ? 'hidden' : undefined }}
                             >
                               <CardCell
                                 droppableId={cellId(project.id, milestone.number)}
@@ -500,7 +551,7 @@ export default function StoryMap() {
                       <td
                         key={project.id}
                         className="align-top p-2"
-                        style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id) }}
+                        style={{ background: 'var(--n-bg)', borderRight: '1px solid var(--n-border)', borderBottom: '1px solid var(--n-border)', width: colW(project.id), minWidth: colW(project.id), visibility: draggingColumnId === project.id ? 'hidden' : undefined }}
                       >
                         <CardCell
                           droppableId={cellId(project.id, null)}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,98 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600;1,400&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --n-bg: #ffffff;
+  --n-sidebar: #f7f6f3;
+  --n-text: rgb(55, 53, 47);
+  --n-text-2: rgba(55, 53, 47, 0.65);
+  --n-text-3: rgba(55, 53, 47, 0.4);
+  --n-border: rgba(55, 53, 47, 0.09);
+  --n-hover: rgba(55, 53, 47, 0.06);
+  --n-hover-strong: rgba(55, 53, 47, 0.1);
+  --n-blue: #2383E2;
+  --n-blue-bg: rgba(35, 131, 226, 0.1);
+  --n-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
+  --n-shadow-lg: 0 4px 16px rgba(0,0,0,0.12), 0 1px 4px rgba(0,0,0,0.08);
+}
+
+html, body {
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--n-bg);
+  color: var(--n-text);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Notion-style scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(55, 53, 47, 0.15);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(55, 53, 47, 0.3);
+}
+
+/* Prose styles for issue body markdown */
+.issue-body {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--n-text);
+}
+.issue-body h1, .issue-body h2, .issue-body h3 {
+  font-weight: 600;
+  margin: 1em 0 0.4em;
+  color: var(--n-text);
+}
+.issue-body h1 { font-size: 1.25rem; }
+.issue-body h2 { font-size: 1.1rem; }
+.issue-body h3 { font-size: 1rem; }
+.issue-body p { margin: 0.5em 0; }
+.issue-body ul, .issue-body ol { padding-left: 1.5em; margin: 0.5em 0; }
+.issue-body li { margin: 0.2em 0; }
+.issue-body code {
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8em;
+  background: rgba(55, 53, 47, 0.08);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+.issue-body pre {
+  background: rgba(55, 53, 47, 0.06);
+  border: 1px solid var(--n-border);
+  border-radius: 6px;
+  padding: 0.75em 1em;
+  overflow-x: auto;
+  margin: 0.75em 0;
+}
+.issue-body pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85em;
+}
+.issue-body a {
+  color: var(--n-blue);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.issue-body blockquote {
+  border-left: 3px solid var(--n-border);
+  padding-left: 0.75em;
+  color: var(--n-text-2);
+  margin: 0.5em 0;
+}
+.issue-body img { max-width: 100%; border-radius: 4px; }
+.issue-body hr {
+  border: none;
+  border-top: 1px solid var(--n-border);
+  margin: 1em 0;
+}


### PR DESCRIPTION
## Summary

- Restyled all components (Header, Login, Setup, StoryMap, IssueCard, ChangeRepoModal) to use a shared `--n-*` CSS token system matching Notion's design language — neutral palette, Inter font, minimal borders, subtle hover states
- Replaced hardcoded Tailwind color classes (`bg-blue-50`, `bg-purple-50`, `border-gray-200`, etc.) with design tokens throughout the story map grid
- Added `ChangeRepoModal` component (new) with Notion card style matching `Setup`
- Fixed drag-and-drop for columns, rows, and issue cards — `provided.draggableProps.style` was being silently discarded, breaking column drag
- Column drag now lifts the entire column (header + all row cells) using `renderClone`, stripping the library-injected `height` that was clipping the clone to header-only
- Removed hover action buttons from issue cards
- Inline wave creation in story map — replaces the modal with an inline form matching the user activity pattern
- No Wave row is always visible so new waves can be created at any time

## Test plan

- [ ] Story map grid renders with Notion styling (neutral headers, sidebar row labels)
- [ ] Dragging a column lifts the full column as one unit
- [ ] Dragging a row and issue cards works correctly
- [ ] Creating a new wave inline in the No Wave row label
- [ ] Creating a new user activity inline in the No User Activity column header
- [ ] ChangeRepoModal opens from sidebar and matches Notion card style
- [ ] Login and Setup screens match Notion card style

🤖 Generated with [Claude Code](https://claude.com/claude-code)