### PR TITLE
Table view should show complete issues

### DIFF
--- a/src/components/StoryMap.tsx
+++ b/src/components/StoryMap.tsx
@@ -469,7 +469,7 @@ export default function StoryMap() {
                           {/* Row label — sticky left, not resizable */}
                           <th
                             {...provided.dragHandleProps}
-                            className="px-3 py-2 text-xs font-medium text-right align-top pt-3 cursor-grab select-none w-[200px] min-w-[200px] max-w-[200px] shrink-0"
+                            className="sticky left-0 z-10 px-3 py-2 text-xs font-medium text-right align-top pt-3 cursor-grab select-none w-[200px] min-w-[200px] max-w-[200px] shrink-0"
                             style={{
                               background: snapshot.isDragging ? 'var(--n-hover-strong)' : 'var(--n-sidebar)',
                               color: 'var(--n-text-2)',

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -217,7 +217,7 @@ type SortDir = 'asc' | 'desc';
 export default function TableView() {
   const {
     issues,
-    showClosedIssues,
+    kanbanShowClosedIssues,
     projects,
     projectIssues,
     kanbanIssueStatuses,
@@ -238,7 +238,7 @@ export default function TableView() {
   }
 
   const visibleIssues = issues
-    .filter((i) => showClosedIssues || i.state === 'open')
+    .filter((i) => kanbanShowClosedIssues || i.state === 'open')
     .filter((i) => {
       if (!filterText.trim()) return true;
       const q = filterText.toLowerCase();


### PR DESCRIPTION
## Summary

- The Table view was reading from `showClosedIssues` (global default: `false`) instead of `kanbanShowClosedIssues` (default: `true`), causing it to hide closed issues on initial load regardless of the toggle state.
- The Header already correctly routes the table view's toggle to `kanbanShowClosedIssues` — this fix aligns the TableView component with that mapping.
- Fixed a secondary bug: milestone row labels in the Grid view were missing `sticky left-0 z-10`, so only the "No Wave / + New Wave" cell stayed fixed when scrolling right, making it appear to overlap unrelated content.

## Implementation notes

`Header.tsx` (lines 90–91) already maps both `kanban` and `table` views to the `kanbanShowClosedIssues` state and `toggleKanbanShowClosedIssues` action. The TableView component simply wasn't consuming the same state, so the toggle had no effect on it and the default behaviour was inverted.

For the sticky bug: the comment on the milestone row `<th>` already read "sticky left, not resizable" — the `sticky left-0 z-10` classes were just missing. All first-column cells (corner z-30, wave labels z-10, No Wave z-10) are now consistently sticky.

## Test plan

- [ ] Open the Table view — all issues (open **and** closed) are visible by default.
- [ ] Click the "show/hide complete issues" toggle in the top bar while in Table view — closed issues are immediately hidden/shown.
- [ ] Switch to Kanban view and toggle there — Table view should reflect the same state when you switch back (shared `kanbanShowClosedIssues`).
- [ ] Switch to Grid view and toggle there — Table view should be unaffected (Grid uses `showClosedIssues`, Table uses `kanbanShowClosedIssues`).
- [ ] Open the Grid view with multiple waves and scroll right — wave labels remain sticky on the left and no longer overlap content.

Closes #86